### PR TITLE
fix: campaign roll dialogs post over htmx, redraw in place, and take the reviewed copy

### DIFF
--- a/n26/core/campaigns.py
+++ b/n26/core/campaigns.py
@@ -368,9 +368,9 @@ class CampaignOperation:
         allow the same territory to come up more than once, and the
         campaign asset's own name is what tells the two apart.
 
-        ``rolled`` is a roll made at the table and entered here rather
-        than generated; it has to be one the die can make, and the record
-        says it was entered. ``rng`` is for a test that wants the dice
+        ``rolled`` is a roll the reader made themselves and typed in
+        rather than one generated here; it has to be one the die can
+        make, and the record says it was a manual roll. ``rng`` is for a test that wants the dice
         loaded.
 
         One log line for one act: the roll is recorded as ASSET_ROLLED
@@ -387,10 +387,7 @@ class CampaignOperation:
         ):
             raise ValueError(f"{membership} is not playing {self.campaign}.")
         if not table.dice:
-            raise Refusal(
-                f"You cannot roll on {table}. It has no dice: it is an ordered "
-                "list, chosen from rather than rolled."
-            )
+            raise Refusal(f"{table} cannot be rolled. It is a list with no dice.")
         if membership is None:
             if (
                 not tables_in_play(
@@ -399,10 +396,7 @@ class CampaignOperation:
                 .filter(pk=table.pk)
                 .exists()
             ):
-                raise Refusal(
-                    f"You cannot roll on {table} for {self.campaign.name}. Only a "
-                    "table built into the campaign can be rolled on for its pool."
-                )
+                raise Refusal(f"{table} is not available to {self.campaign.name}.")
         elif table.pk not in {
             held.pk
             for held in tables_held_by(
@@ -414,9 +408,10 @@ class CampaignOperation:
             # A staged table the gang holds is one the roller may use only
             # if they may see staged content: the roll is where a Territory
             # is newly chosen for the campaign.
+            gang = membership.gang.name
             raise Refusal(
-                f"{membership.gang.name} cannot roll on {table}. Only a gang "
-                "that holds that table can."
+                f"{gang} cannot roll for a {table.asset_type.label_singular.lower()} "
+                f"from {table}. That table is not available to {gang}."
             )
 
         dice = Dice(table.dice)
@@ -435,12 +430,11 @@ class CampaignOperation:
         entry = table.landing(rolled, list(entries))
         if entry is None:
             raise Refusal(
-                f"No entry on {table} covers a roll of {rolled}. Fill that gap in "
-                "the table first."
+                f"Nothing on {table} covers a roll of {rolled}. Fill that gap first."
             )
         campaign_asset = self._keep(entry.asset)
         who = f" for {membership.gang.name}" if membership is not None else ""
-        note = f"Rolled {rolled} on {_table_named(table)}{who}: {campaign_asset}."
+        note = f"Rolled {rolled} from {_table_named(table)}{who}: {campaign_asset}."
         if entered:
             note = f"{note} {ROLL_ENTERED}"
         self.event(CampaignEvent.Kind.ASSET_ROLLED, note=note)
@@ -781,9 +775,9 @@ class CampaignOperation:
             self.campaign.additions_id,
         ):
             raise Refusal(
-                f"You cannot open {table} here. It lists "
-                f"{table.asset_type.plural}, which {self.campaign.name} does "
-                "not deal in."
+                f"You cannot make {table} available here. It contains "
+                f"{table.asset_type.plural.lower()}, which {self.campaign.name} "
+                "does not deal in."
             )
         if (
             tables_in_play(self.campaign, include_staged=True)
@@ -828,8 +822,8 @@ class CampaignOperation:
             archived=False,
         ).exists():
             raise Refusal(
-                f"You cannot close {table}. {self.campaign.campaign_type} gives "
-                "it to every gang."
+                f"You cannot withdraw {table}. It is included with "
+                f"{self.campaign.campaign_type}."
             )
         members = list(
             DefaultAssignment.objects.filter(

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -691,7 +691,7 @@ class AddLabelForm(forms.Form):
 
 class RollAssetForm(forms.Form):
     """A roll on one of the tables offered: which table, and the roll
-    made at the table where it was made there rather than here.
+    where the reader made it themselves rather than here.
 
     Whether an entered roll is one the die can make is the operation's
     question, since only it knows which table's die is being rolled by
@@ -702,15 +702,15 @@ class RollAssetForm(forms.Form):
         queryset=None,
         label="Table",
         error_messages={
-            "invalid_choice": "That table is not one you can roll on here.",
+            "invalid_choice": "That table is not available here.",
             "required": "Select a table.",
         },
     )
     rolled = forms.IntegerField(
         required=False,
         min_value=1,
-        label="Enter the roll you made at the table",
-        help_text="Optional. Leave blank and the roll is made here.",
+        label="Your own roll",
+        help_text="Optional. Leave blank and the roll is made for you.",
     )
 
     def __init__(self, *args, tables, **kwargs):
@@ -738,7 +738,7 @@ class OpenTablesForm(forms.Form):
         queryset=None,
         required=False,
         error_messages={
-            "invalid_choice": "That table is not one you can open here.",
+            "invalid_choice": "You cannot make that table available here.",
         },
     )
 
@@ -763,10 +763,7 @@ class NewTableForm(forms.Form):
     dice = forms.ChoiceField(
         required=False,
         label="Dice",
-        help_text=(
-            "The die the table is rolled on. Leave blank for an ordered "
-            "list that is chosen from rather than rolled."
-        ),
+        help_text="The table's die. Choose Not rolled for a plain list.",
     )
 
     def __init__(self, *args, asset_types, **kwargs):

--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -1357,23 +1357,32 @@ def _tell_campaign(e):
             what = f"the asset {e.note}" if e.note else "an asset"
             return (Span(f"removed {what}"),), "campaign"
         case kinds.ASSET_ROLLED:
-            # The note is the whole sentence — "Rolled 34 on the Territory
-            # Selection Table: Old Ruins." — written to stand on its own.
+            # The note is the whole sentence — "Rolled 34 from the Territory
+            # Selection Table: Old Ruins." — written to stand on its own,
+            # with the manual-roll marker as a second sentence after it.
             # Here the actor's name leads, so it loses its capital and its
-            # stop, and the mark of an entered roll follows in its own words.
-            said, _, entered = e.note.partition(". ")
+            # stop, and a manual roll is marked in brackets after it. The
+            # marker is taken off the end by name: a gang or a table called
+            # "Dr. Skabb's" has a stop of its own inside the sentence.
+            from n26.core.operations import ROLL_ENTERED, ROLL_ENTERED_BEFORE
+
+            said, manual = e.note, False
+            for marker in (ROLL_ENTERED, ROLL_ENTERED_BEFORE):
+                if said.endswith(f" {marker}"):
+                    said, manual = said[: -(len(marker) + 1)], True
+                    break
             if not said:
-                return (Span("rolled on a table"),), "campaign"
+                return (Span("made a roll"),), "campaign"
             said = said[0].lower() + said[1:].removesuffix(".")
-            if entered:
-                said = f"{said}, entered from a roll at the table"
+            if manual:
+                said = f"{said} (manual roll)"
             return (Span(said),), "campaign"
         case kinds.TABLE_OPENED:
             what = f"the table {e.note}" if e.note else "a table"
-            return (Span(f"opened {what} to every gang"),), "campaign"
+            return (Span(f"made {what} available to every gang"),), "campaign"
         case kinds.TABLE_CLOSED:
             what = f"the table {e.note}" if e.note else "a table"
-            return (Span(f"closed {what}"),), "campaign"
+            return (Span(f"withdrew {what}"),), "campaign"
         case kinds.TABLE_CREATED:
             what = f"the table {e.note}" if e.note else "a table"
             return (Span(f"created {what}"),), "campaign"

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -286,9 +286,13 @@ class NotOnOffer(Refusal):
 #: campaign is asked about once rather than on every event it writes.
 _UNASKED = object()
 
-#: The note on a roll that was made at the table and entered, which is
+#: The note on a roll the reader made themselves and typed in, which is
 #: how the record tells one from a roll the page generated.
-ROLL_ENTERED = "Rolled at the table and entered here."
+ROLL_ENTERED = "Manual roll."
+
+#: What the same note said before the wording changed. Rolls recorded
+#: under it still read as manual ones.
+ROLL_ENTERED_BEFORE = "Rolled at the table and entered here."
 
 #: The reason on a status change Clean House made, which is how the
 #: history tells the cycle's end from the owner's own hand.

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -3123,6 +3123,12 @@ def boon_said(modifier):
     from n26.library.prose import GANG as GANG_CARRIAGE
     from n26.library.prose import sentence_for
 
+    # The short form reads as "the holding gang gets this", so it is only
+    # right for a boon scoped to the gang. One aimed at the gang's models
+    # says who in its whole sentence, and loses that if shortened.
+    scope = modifier.targets_gang
+    if scope is None:
+        return sentence_for(modifier, carriage=GANG_CARRIAGE).text
     effect = modifier.effect
     if isinstance(effect, ContributesToCounter):
         said = f"+{effect.amount} {effect.counter.name}."
@@ -3131,8 +3137,7 @@ def boon_said(modifier):
         said = f"{getattr(thing, 'name', None) or thing}."
     else:
         return sentence_for(modifier, carriage=GANG_CARRIAGE).text
-    scope = modifier.targets_gang
-    if scope is not None and scope.is_conditional:
+    if scope.is_conditional:
         who = ", ".join(str(row) for row in scope._narrowing_rows())
         return f"{who[0].upper()}{who[1:]}: {said}"
     return said

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -1193,9 +1193,13 @@ class CampaignAssetEntry:
     ``name`` is the name the arbitrator gave the asset in this campaign,
     else the library asset's own; ``asset_name`` is the library asset's
     only where the two differ, so a renamed asset still says what it is.
-    ``boons`` are the asset's modifiers as sentences, the authoring page's
-    own words for what holding the asset does — every modifier but the
-    Income contribution, which the ``income`` column already prints.
+    ``boons`` are what holding the asset does beyond its income figure,
+    one line per modifier, each in the register of the Income column:
+    "Goliath gangs: +10 Income." for a contribution only some gangs get,
+    "Goliath gangs: Goliath Controlled." for a rule only some gangs get,
+    "Goliath Controlled." for one every holder gets. The unconditional
+    Income contribution is the ``income`` column's and is never repeated
+    here (``boon_said``).
     """
 
     campaign_asset_id: str
@@ -2880,8 +2884,6 @@ def render_campaign(campaign, viewer=None):
     from n26.core.render import GANG_SLOT_HOST, choice_lines
     from n26.library.income import boons_of, income_of
     from n26.library.models import Asset, AssetType, Modifier
-    from n26.library.prose import GANG as GANG_CARRIAGE
-    from n26.library.prose import sentence_for
     from n26.library.references import reading_sentences
     from n26.library.staged import sees_staged
 
@@ -3062,8 +3064,7 @@ def render_campaign(campaign, viewer=None):
                 asset_name=campaign_asset.asset.name if campaign_asset.name else "",
                 income=income_of(campaign_asset.asset),
                 boons=[
-                    sentence_for(modifier, carriage=GANG_CARRIAGE).text
-                    for modifier in boons_of(campaign_asset.asset)
+                    boon_said(modifier) for modifier in boons_of(campaign_asset.asset)
                 ],
                 held=holder is not None,
                 holder=holder.gang.name if holder else "",
@@ -3104,6 +3105,37 @@ def render_campaign(campaign, viewer=None):
 #: How many territories the rules generate for each player at the table
 #: when a campaign is set up.
 TERRITORIES_PER_PLAYER = 3
+
+
+def boon_said(modifier):
+    """One of an asset's boons as the campaign page's Boons column says
+    it: the gangs it applies to, then what it does, in the register of
+    the Income column beside it.
+
+    "+10 Income." for a counter contribution, "Goliath Controlled." for
+    a rule or other thing the holder gains — by its plain name, since the
+    row already names the territory the rule is annotated with. A boon
+    only some gangs get leads with the scope's own words: "Goliath gangs:
+    +10 Income.". An effect this column has no short form for falls back
+    to the authoring page's whole sentence.
+    """
+    from n26.library.models.modifier import AddsAssignable, ContributesToCounter
+    from n26.library.prose import GANG as GANG_CARRIAGE
+    from n26.library.prose import sentence_for
+
+    effect = modifier.effect
+    if isinstance(effect, ContributesToCounter):
+        said = f"+{effect.amount} {effect.counter.name}."
+    elif isinstance(effect, AddsAssignable) and effect.thing is not None:
+        thing = effect.thing
+        said = f"{getattr(thing, 'name', None) or thing}."
+    else:
+        return sentence_for(modifier, carriage=GANG_CARRIAGE).text
+    scope = modifier.targets_gang
+    if scope is not None and scope.is_conditional:
+        who = ", ".join(str(row) for row in scope._narrowing_rows())
+        return f"{who[0].upper()}{who[1:]}: {said}"
+    return said
 
 
 def _held_table(table):

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -1148,6 +1148,17 @@ class HeldTable:
     dice: str
     die: str
 
+    @property
+    def lowest(self):
+        """The lowest roll the table's die can make — 11 on a D66."""
+        rolls = Dice.rolls(self.dice)
+        return rolls[0] if rolls else None
+
+    @property
+    def highest(self):
+        rolls = Dice.rolls(self.dice)
+        return rolls[-1] if rolls else None
+
 
 @dataclass
 class StartingRoll:

--- a/n26/core/templates/cotton/n26/campaign_assets.html
+++ b/n26/core/templates/cotton/n26/campaign_assets.html
@@ -17,7 +17,7 @@ ones — the view fills them for the arbitrator, and Unassign and the transfer
 for the owner of the holding gang, whose transfer reads "Hand over".
 
 The Roll control takes the asset type's own word too — "Roll territory" —
-and is drawn only where the campaign holds a rolled table of the type.
+and is drawn only where the campaign has a rolled table of the type.
 
   :table — a n26.render.CampaignAssetTable.
 {% endcomment %}
@@ -46,7 +46,7 @@ and is drawn only where the campaign holds a rolled table of the type.
                                  href="{{ table.roll_href }}"
                                  hx-get="{{ table.roll_href }}"
                                  hx-swap="none"
-                                 title="Roll on a table for a {{ table.label|lower }} nobody holds yet">Roll {{ table.label|lower }}</c-ui.button>
+                                 title="Roll for a {{ table.label|lower }}. It is added to the campaign, unclaimed.">Roll {{ table.label|lower }}</c-ui.button>
                 {% endif %}
                 {% if table.add_href %}
                     <c-ui.button size="xs"
@@ -58,7 +58,7 @@ and is drawn only where the campaign holds a rolled table of the type.
                     <c-ui.button size="xs"
                                  variant="default"
                                  href="{{ table.create_href }}"
-                                 title="Write a new {{ table.label|lower }} for this campaign alone">Create {{ table.label|lower }}</c-ui.button>
+                                 title="Create a new {{ table.label|lower }} for this campaign">Create {{ table.label|lower }}</c-ui.button>
                 {% endif %}
             </div>
         {% endif %}

--- a/n26/core/templates/cotton/n26/campaign_figures.html
+++ b/n26/core/templates/cotton/n26/campaign_figures.html
@@ -19,7 +19,7 @@ drops onto a second line stops reading as a strip.
 
 <div class="overflow-x-auto {{ class }}">
     <dl class="flex w-max items-stretch">
-        <c-n26.wealth.figure short="Gangs" full="Gangs at the table" unit="" :value="sheet.gang_count" />
+        <c-n26.wealth.figure short="Gangs" full="Gangs in this campaign" unit="" :value="sheet.gang_count" />
         <c-n26.wealth.figure short="Held" full="Assets held by a gang" unit="" :value="sheet.assets_held" />
         <c-n26.wealth.figure short="Unclaimed" full="Assets nobody holds" unit="" :value="sheet.assets_unclaimed" />
         <c-n26.wealth.figure short="Battles" full="Battles fought" unit="" :value="sheet.battles_fought" />

--- a/n26/core/templates/cotton/n26/roll_result.html
+++ b/n26/core/templates/cotton/n26/roll_result.html
@@ -36,7 +36,7 @@ and no form of its own: the page owns the form.
             </span>
             <span class="block text-muted">
                 {% if roll.is_spent %}Already applied: {{ roll.applied }}. Roll again for another result.{% elif roll.landed %}{% if roll.threshold %}High enough for{% else %}Landed on{% endif %} {% for name in roll.landed %}{% if not forloop.first %}, {% endif %}<strong class="font-semibold text-ink-900 dark:text-ink-100">{{ name }}</strong>{% endfor %}.{% else %}This table has no result for {{ roll.total }}.{% endif %}
-                {% if roll.entered %}Rolled at the table and entered here.{% endif %}
+                {% if roll.entered %}Manual roll.{% endif %}
             </span>
         </span>
     </span>

--- a/n26/core/templates/cotton/n26/roll_table.html
+++ b/n26/core/templates/cotton/n26/roll_table.html
@@ -39,8 +39,8 @@ passed to it would print a second class attribute and drop its styling.
     <div class="flex items-center gap-2">
         <div class="w-56">
             <c-ui.input name="rolled" type="number" inputmode="numeric"
-                        placeholder="Your roll from the table ({{ table.lowest }}–{{ table.highest }})"
-                        aria-label="The number you rolled at the table" />
+                        placeholder="Your own roll ({{ table.lowest }}–{{ table.highest }})"
+                        aria-label="The roll you made yourself" />
         </div>
         <c-ui.button type="submit" name="act" value="enter" variant="default">Enter</c-ui.button>
     </div>

--- a/n26/core/templates/cotton/n26/view/campaign_sheet.html
+++ b/n26/core/templates/cotton/n26/view/campaign_sheet.html
@@ -19,6 +19,11 @@ controls, then the sections. The gangs table and the assets tables are drawn
 here from the sheet; the players, the battles and the log arrive as slots,
 because each names addresses this component has no business knowing.
 
+The figures, the gangs table and the Assets section each sit in a host with
+a stable id (n26/includes/campaign_*.html): a roll made on the campaign page
+redraws those out of band, and only a page holding every host may let its
+dialogs post over htmx.
+
 The lead reads "Territory campaign · arbitrated by tom", so the type is said
 once, here, and nowhere else on the page. The budget is a fact a reader can
 click into where `edit_href` is given — the facts strip is a strip of
@@ -43,7 +48,9 @@ only where the address is filled.
     controls of each section, at the far end of its heading, drawn after the
     sheet's own.
   players, battles, log — the contents of those three sections.
-  log_count — the log heading's count, e.g. "12 earlier acts not shown".
+  log_count — the log heading's count, e.g. "12 earlier acts not shown". May
+    be markup: the campaign page passes it as a slot holding the host a roll's
+    update redraws.
   log_href — where the whole log is read. Given, the Log heading carries a
     "Full log" link; empty, the count stands alone.
 {% endcomment %}
@@ -103,7 +110,7 @@ only where the address is filled.
             an unfilled slot here would draw that one up beside the title.
             {% endcomment %}
             <c-slot name="actions">
-                <c-n26.campaign-figures :sheet="sheet" />
+                {% include "n26/includes/campaign_figures.html" %}
             </c-slot>
         </c-n26.page-header>
 
@@ -161,41 +168,17 @@ only where the address is filled.
                 {{ gangs_actions }}
             </c-slot>
         {% endif %}
-        {% if sheet.gangs %}
-            <c-n26.campaign-gangs :sheet="sheet" />
-        {% else %}
-            <p class="text-sm text-muted">No gangs in this campaign yet.</p>
-        {% endif %}
+        {% include "n26/includes/campaign_gangs.html" %}
     </c-n26.section>
 
     {% comment %}
-    One table per asset type whose ownership is Holding, under one heading.
-    A possession has no table here: every gang has its own, and it is on the
-    gang's row above. An asset type the arbitrator adds is one more table,
-    so the control that adds one sits on this heading.
+    The Assets section is an include the campaign page's partial update
+    draws too, in a host of its own: a roll changes its count as well as
+    adding a line, so the whole section is what an update replaces. The
+    gangs table and the figures sit in hosts of their own for the same
+    reason (see n26/includes/campaign_update.html).
     {% endcomment %}
-    <c-n26.section id="assets" title="Assets" count="{% if sheet.asset_count %}{{ sheet.assets_held }} held, {{ sheet.assets_unclaimed }} unclaimed{% endif %}">
-        {% if assets_actions.strip or sheet.add_asset_type_href or sheet.tables_href %}
-            <c-slot name="actions">
-                {% if sheet.tables_href %}
-                    <c-ui.button size="sm" variant="default" href="{{ sheet.tables_href }}">Tables</c-ui.button>
-                {% endif %}
-                {% if sheet.add_asset_type_href %}
-                    <c-ui.button size="sm" variant="default" href="{{ sheet.add_asset_type_href }}">Add asset type</c-ui.button>
-                {% endif %}
-                {{ assets_actions }}
-            </c-slot>
-        {% endif %}
-        {% if sheet.assets %}
-            <div class="flex flex-col gap-6">
-                {% for table in sheet.assets %}
-                    <c-n26.campaign-assets :table="table" />
-                {% endfor %}
-            </div>
-        {% else %}
-            <p class="text-sm text-muted">{{ sheet.campaign_type }} has no asset types with Holding ownership.</p>
-        {% endif %}
-    </c-n26.section>
+    {% include "n26/includes/campaign_assets_section.html" %}
 
     {% comment %}
     Side by side from xl, where both are short lists and a page that stacked
@@ -212,7 +195,8 @@ only where the address is filled.
         </c-n26.section>
     </div>
 
-    <c-n26.section id="log" title="Log" count="{{ log_count }}">
+    <c-n26.section id="log" title="Log">
+        {% if log_count.strip %}<c-slot name="count">{{ log_count }}</c-slot>{% endif %}
         {% if log_href %}
             <c-slot name="actions">
                 <c-ui.button size="sm" variant="default" href="{{ log_href }}">Full log</c-ui.button>

--- a/n26/core/templates/n26/campaign.html
+++ b/n26/core/templates/n26/campaign.html
@@ -32,8 +32,10 @@ reader's other campaigns — the same pattern a gang's screens use.
 {% block content %}
     <c-n26.view.campaign-sheet :sheet="sheet"
                                edit_href="{% if yours %}{% url 'n26-edit-campaign' campaign.pk %}{% endif %}"
-                               log_count="{% if more_acts %}{{ more_acts }} earlier act{{ more_acts|pluralize }} not shown{% endif %}"
                                log_href="{{ log_href }}">
+        <c-slot name="log_count">
+            {% include "n26/includes/campaign_log_count.html" %}
+        </c-slot>
         <c-slot name="breadcrumb">
             <c-ui.breadcrumbs>
                 <c-ui.breadcrumbs.item>
@@ -212,37 +214,19 @@ reader's other campaigns — the same pattern a gang's screens use.
         {% comment %}
         Cut to the most recent acts, with a count of what is not drawn: a
         campaign played for a year would otherwise push its own facts off
-        the bottom of the page.
+        the bottom of the page. In a host of its own, because a roll made
+        on this page writes a line here and redraws the list in place.
         {% endcomment %}
         <c-slot name="log">
-            {% if acts %}
-                <ol class="flex flex-col">
-                    {% for act in acts %}
-                        <li class="flex gap-3 border-b border-box-border/50 py-2 last:border-b-0">
-                            <time datetime="{{ act.when|date:'c' }}"
-                                  title="{{ act.when }}"
-                                  class="w-24 shrink-0 pt-px text-right text-sm tabular-nums whitespace-nowrap text-muted">
-                                {{ act.when|date:"j M H:i" }}
-                            </time>
-                            <div class="min-w-0 flex-1">
-                                <p class="text-base">
-                                    {% if act.actor %}<span class="font-medium">{{ act.actor }}</span>{% endif %}
-                                    {% for span in act.spans %}{% if span.href %}<c-n26.link href="{{ span.href }}" tone="current">{{ span.text }}</c-n26.link>{% else %}{{ span.text }}{% endif %}{% endfor %}
-                                </p>
-                                {% if act.gang_name %}<p class="text-sm text-muted">{{ act.gang_name }}</p>{% endif %}
-                            </div>
-                        </li>
-                    {% endfor %}
-                </ol>
-            {% else %}
-                <p class="text-sm text-muted">Nothing in the log yet.</p>
-            {% endif %}
+            {% include "n26/includes/campaign_log.html" %}
         </c-slot>
     </c-n26.view.campaign-sheet>
     {% comment %}
     The roll questions' host, drawn even when empty so a Roll control can
     fetch its panel into it without rebuilding the page. Outside the sheet:
-    each panel is a form of its own.
+    each panel is a form of its own. The panels post over htmx, which only
+    this page may let them do: it holds every host the update names — the
+    figures, the gangs table, the Assets section, the log and this one.
     {% endcomment %}
     {% if yours %}
         {% include "n26/includes/campaign_roll_dialogs.html" with redrawn=False %}

--- a/n26/core/templates/n26/campaign_table.html
+++ b/n26/core/templates/n26/campaign_table.html
@@ -1,11 +1,14 @@
 {% extends "n26/layouts/base.html" %}
 {% load navigation %}
 {% comment %}
-One of the campaign's own tables: its entries in roll order, whether its
-bands cover its die, and the form that adds an entry. The assets offered are
-the ones the campaign may add by hand of the table's asset type, so a table
-lists nothing the campaign could not add. Removing an entry is a POST from
-its row; what was already rolled stays in the campaign.
+One of the campaign's own tables: what it contains in roll order, whether
+its bands cover its die, and the form that adds to it. The assets offered
+are the ones the campaign may add by hand of the table's asset type, so a
+table contains nothing the campaign could not add. Removing one is a POST
+from its row; what was already rolled stays in the campaign.
+
+Every word for what the table contains is the asset type's own — `label`
+and `plural` from the view — so a table of territories says territories.
 
 The coverage check is the authoring page's own include, so a table is judged
 the same way wherever it is edited.
@@ -21,9 +24,9 @@ the same way wherever it is edited.
 {% block content %}
     <c-n26.form-page action="{% url 'n26-campaign-table' campaign.pk table.pk %}"
                      title="{{ table }}"
-                     lead="{% if table.dice %}Rolled on a {{ table.get_dice_display }}. Every roll the die can make should land on exactly one entry: give each entry the lowest and highest roll that lands on it.{% else %}An ordered list, chosen from rather than rolled.{% endif %}"
+                     lead="{% if table.dice %}Rolled with a {{ table.get_dice_display }}. Every roll the die can make should land on exactly one {{ label }}: give each {{ label }} the lowest and highest roll that lands on it.{% else %}A plain list, not rolled for.{% endif %}"
                      :form="form"
-                     submit_label="Add entry"
+                     submit_label="Add {{ label }}"
                      cancel_url="{{ back }}"
                      cancel_label="Back to tables">
         <c-slot name="breadcrumb">
@@ -42,7 +45,7 @@ the same way wherever it is edited.
             </c-ui.breadcrumbs>
         </c-slot>
         {% csrf_token %}
-        <c-n26.form-section title="Entries">
+        <c-n26.form-section title="{{ table.asset_type.plural }}">
             {% if coverage %}
                 {% include "authoring/_coverage.html" with coverage=coverage.coverage unclaimed_said=coverage.unclaimed_said doubled_said=coverage.doubled_said bandless_said=coverage.bandless_said %}
             {% endif %}
@@ -65,7 +68,7 @@ the same way wherever it is edited.
                                                  type="submit"
                                                  form="remove-{{ forloop.counter }}"
                                                  aria-label="Remove {{ entry.label }}"
-                                                 title="Remove this entry">
+                                                 title="Remove this {{ label }}">
                                         <span class="n26-icon-only">
                                             <c-n26.icon name="x-mark" class="size-4" />
                                         </span>
@@ -76,13 +79,13 @@ the same way wherever it is edited.
                     </tbody>
                 </c-ui.table>
             {% else %}
-                <p class="text-sm text-muted">No entries yet. Add the {{ table.asset_type.plural|lower }} a roll on this table can land on.</p>
+                <p class="text-sm text-muted">No {{ plural }} yet. Add the {{ plural }} a roll can land on.</p>
             {% endif %}
         </c-n26.form-section>
-        <c-n26.form-section title="Add an entry">
+        <c-n26.form-section title="Add a {{ label }}">
             {% if assets %}
-                <c-n26.radio-cards label="{{ table.asset_type.label_singular }} *"
-                                   description="The {{ table.asset_type.plural|lower }} this campaign deals in."
+                <c-n26.radio-cards label="{{ table.asset_type.label_singular }}"
+                                   description="The {{ plural }} available to this campaign."
                                    :form="form"
                                    name="asset"
                                    min="12rem">
@@ -95,7 +98,7 @@ the same way wherever it is edited.
                 </c-n26.radio-cards>
             {% else %}
                 <c-ui.alert variant="info" title="Nothing to add">
-                    This campaign has no {{ table.asset_type.plural|lower }} yet. Create one from the campaign page first.
+                    This campaign has no {{ plural }} yet. Create one from the campaign page first.
                 </c-ui.alert>
             {% endif %}
             {% if table.dice %}

--- a/n26/core/templates/n26/campaign_tables.html
+++ b/n26/core/templates/n26/campaign_tables.html
@@ -1,15 +1,17 @@
 {% extends "n26/layouts/base.html" %}
 {% load navigation %}
 {% comment %}
-Which asset tables every gang in the campaign may roll on, by asset type.
-The campaign type's own tables are given and carry no control. Every other
-table of the type the arbitrator may open — a system pack's, or one written
+The tables the gangs in the campaign can use, by asset type. The campaign
+type's own tables are included and carry no control. Every other table of
+the type the arbitrator may make available — a system pack's, or one written
 for this campaign — carries a tick. Ticked, the table is built into the
-campaign's own campaign type, so every gang holds it; unticked, it is taken
-out again, and nothing a gang already rolled is taken back.
+campaign's own campaign type, so every gang holds it; unticked, it is
+withdrawn, and nothing a gang already rolled is taken back.
 
 One form over every tick, saved together: the view reads the ticks against
-what stood before and opens or closes only what changed.
+what stood before and changes only what moved. The words are the view's:
+each section's intro, its help and its empty line take the asset type's own
+word for what a table contains.
 {% endcomment %}
 {% block head_title %}Tables in {{ campaign.name }}{% endblock head_title %}
 {% block nav_switcher %}
@@ -22,7 +24,7 @@ what stood before and opens or closes only what changed.
 {% block content %}
     <c-n26.form-page action="{% url 'n26-campaign-tables' campaign.pk %}"
                      title="Tables"
-                     lead="The tables a gang rolls on for its starting territory, and the ones you roll on for the campaign's pool. A gang may roll on any table it holds: the ones the campaign type gives, the ones its gang type gives, and any you open here to every gang."
+                     lead="{{ lead }}"
                      submit_label="Save"
                      submit_variant="primary"
                      cancel_url="{{ back }}">
@@ -48,6 +50,7 @@ what stood before and opens or closes only what changed.
         {% csrf_token %}
         {% for section in sections %}
             <c-n26.form-section title="{{ section.asset_type.plural }}">
+                <p class="text-muted">{{ section.intro }}</p>
                 {% if section.given %}
                     <div class="flex flex-col gap-2">
                         {% for table in section.given %}
@@ -56,15 +59,15 @@ what stood before and opens or closes only what changed.
                                     <span class="font-semibold text-ink-900 dark:text-ink-100">{{ table.name }}</span>
                                     <span class="block text-sm text-muted">{{ table.said }}</span>
                                 </span>
-                                <span class="text-sm text-muted">Given by {{ campaign.campaign_type }}. Every gang holds it.</span>
+                                <span class="text-sm text-muted">Included with {{ campaign.campaign_type }}. Available to every gang.</span>
                             </div>
                         {% endfor %}
                     </div>
                 {% endif %}
                 {% if section.offered %}
                     <fieldset>
-                        <legend class="mb-1.5 block font-semibold text-ink-900 dark:text-ink-100">Every gang may roll here</legend>
-                        <p class="mb-2 text-muted">Tick a table to give it to every gang in the campaign. Untick to stop giving it. Anything already rolled on it stays in the campaign.</p>
+                        <legend class="mb-1.5 block font-semibold text-ink-900 dark:text-ink-100">Available to every gang</legend>
+                        <p class="mb-2 text-muted">{{ section.ticks_help }}</p>
                         <div class="flex flex-col gap-2">
                             {% for table in section.offered %}
                                 <div>
@@ -76,7 +79,7 @@ what stood before and opens or closes only what changed.
                                     {% if table.href %}
                                         <div class="mt-1 pl-4">
                                             <c-n26.link href="{{ table.href }}" class="text-sm">
-                                                Entries
+                                                {{ section.asset_type.plural }}
                                             </c-n26.link>
                                         </div>
                                     {% endif %}
@@ -85,12 +88,12 @@ what stood before and opens or closes only what changed.
                         </div>
                     </fieldset>
                 {% elif not section.given %}
-                    <p class="text-sm text-muted">No tables of {{ section.asset_type.plural|lower }} yet. Create one to roll on.</p>
+                    <p class="text-sm text-muted">{{ section.empty }}</p>
                 {% endif %}
             </c-n26.form-section>
         {% empty %}
-            <c-ui.alert variant="info" title="Nothing to roll for">
-                {{ campaign.campaign_type }} has no asset types with Holding ownership, so there is nothing to put on a table.
+            <c-ui.alert variant="info" title="No tables possible">
+                Every asset type in {{ campaign.campaign_type }} is a possession, and possessions are not rolled for.
             </c-ui.alert>
         {% endfor %}
     </c-n26.form-page>

--- a/n26/core/templates/n26/includes/campaign_assets_section.html
+++ b/n26/core/templates/n26/includes/campaign_assets_section.html
@@ -1,0 +1,45 @@
+{% comment %}
+The Assets section — one table per asset type whose ownership is Holding,
+under one heading with its count and the arbitrator's controls — in the host
+a roll's update replaces. Drawn by the campaign sheet component and by
+campaign_update.html from the same include, so the two cannot drift.
+
+A possession has no table here: every gang has its own, and it is on the
+gang's row above. An asset type the arbitrator adds is one more table, so the
+control that adds one sits on this heading. The whole section is the host
+because a roll changes the heading's count as well as adding a line.
+
+Expects `sheet` with its addresses filled and `assets_actions` (the caller's
+extra controls, usually empty); `redrawn` marks the copy an update delivers.
+{% endcomment %}
+<div id="n26-campaign-assets"
+     {% if redrawn %}hx-swap-oob="true"{% endif %}>
+    <c-n26.section id="assets"
+                   title="Assets"
+                   count="{% if sheet.asset_count %}{{ sheet.assets_held }} held, {{ sheet.assets_unclaimed }} unclaimed{% endif %}">
+        {% if assets_actions.strip or sheet.add_asset_type_href or sheet.tables_href %}
+            <c-slot name="actions">
+                {% if sheet.tables_href %}
+                    <c-ui.button size="sm" variant="default" href="{{ sheet.tables_href }}">
+                        Tables
+                    </c-ui.button>
+                {% endif %}
+                {% if sheet.add_asset_type_href %}
+                    <c-ui.button size="sm" variant="default" href="{{ sheet.add_asset_type_href }}">
+                        Add asset type
+                    </c-ui.button>
+                {% endif %}
+                {{ assets_actions }}
+            </c-slot>
+        {% endif %}
+        {% if sheet.assets %}
+            <div class="flex flex-col gap-6">
+                {% for table in sheet.assets %}
+                    <c-n26.campaign-assets :table="table" />
+                {% endfor %}
+            </div>
+        {% else %}
+            <p class="text-sm text-muted">{{ sheet.campaign_type }} has no asset types with Holding ownership.</p>
+        {% endif %}
+    </c-n26.section>
+</div>

--- a/n26/core/templates/n26/includes/campaign_figures.html
+++ b/n26/core/templates/n26/includes/campaign_figures.html
@@ -1,0 +1,10 @@
+{% comment %}
+The campaign's headline figures, in the host a roll's update replaces.
+Expects `sheet`; `redrawn` marks the copy an update delivers, which
+replaces the one on the page by id. A roll moves Held or Unclaimed by one,
+so the whole strip is redrawn — see campaign_update.html.
+{% endcomment %}
+<div id="n26-campaign-figures"
+     {% if redrawn %}hx-swap-oob="true"{% endif %}>
+    <c-n26.campaign-figures :sheet="sheet" />
+</div>

--- a/n26/core/templates/n26/includes/campaign_gangs.html
+++ b/n26/core/templates/n26/includes/campaign_gangs.html
@@ -1,0 +1,14 @@
+{% comment %}
+The gangs table, or the line saying there is none yet, in the host a roll's
+update replaces. Expects `sheet` with its addresses filled; `redrawn` marks
+the copy an update delivers. A starting roll writes a new name into one
+gang's cell, and the table is redrawn whole rather than the cell: what
+changed is decided by the sheet, not by the control that asked.
+{% endcomment %}
+<div id="n26-campaign-gangs" {% if redrawn %}hx-swap-oob="true"{% endif %}>
+    {% if sheet.gangs %}
+        <c-n26.campaign-gangs :sheet="sheet" />
+    {% else %}
+        <p class="text-sm text-muted">No gangs in this campaign yet.</p>
+    {% endif %}
+</div>

--- a/n26/core/templates/n26/includes/campaign_log.html
+++ b/n26/core/templates/n26/includes/campaign_log.html
@@ -1,0 +1,30 @@
+{% comment %}
+The campaign's recent acts, oldest first, in the host a roll's update
+replaces. Expects `acts` from the view; `redrawn` marks the copy an update
+delivers. Cut to the most recent acts by the view, with the count of what
+is not drawn on the section's heading.
+{% endcomment %}
+<div id="n26-campaign-log" {% if redrawn %}hx-swap-oob="true"{% endif %}>
+    {% if acts %}
+        <ol class="flex flex-col">
+            {% for act in acts %}
+                <li class="flex gap-3 border-b border-box-border/50 py-2 last:border-b-0">
+                    <time datetime="{{ act.when|date:'c' }}"
+                          title="{{ act.when }}"
+                          class="w-24 shrink-0 pt-px text-right text-sm tabular-nums whitespace-nowrap text-muted">
+                        {{ act.when|date:"j M H:i" }}
+                    </time>
+                    <div class="min-w-0 flex-1">
+                        <p class="text-base">
+                            {% if act.actor %}<span class="font-medium">{{ act.actor }}</span>{% endif %}
+                            {% for span in act.spans %}{% if span.href %}<c-n26.link href="{{ span.href }}" tone="current">{{ span.text }}</c-n26.link>{% else %}{{ span.text }}{% endif %}{% endfor %}
+                        </p>
+                        {% if act.gang_name %}<p class="text-sm text-muted">{{ act.gang_name }}</p>{% endif %}
+                    </div>
+                </li>
+            {% endfor %}
+        </ol>
+    {% else %}
+        <p class="text-sm text-muted">Nothing in the log yet.</p>
+    {% endif %}
+</div>

--- a/n26/core/templates/n26/includes/campaign_log_count.html
+++ b/n26/core/templates/n26/includes/campaign_log_count.html
@@ -1,0 +1,9 @@
+{% comment %}
+The Log heading's count of acts not drawn, in the host a roll's update
+replaces. Expects `more_acts` from the view; `redrawn` marks the copy an
+update delivers. Sits on the section's heading, outside the list's own host,
+which is why it needs one: a roll writes a line, and on a campaign already
+showing its limit the count of what is not shown moves with it.
+{% endcomment %}
+<span id="n26-campaign-log-count"
+      {% if redrawn %}hx-swap-oob="true"{% endif %}>{% if more_acts %}{{ more_acts }} earlier act{{ more_acts|pluralize }} not shown{% endif %}</span>

--- a/n26/core/templates/n26/includes/campaign_roll_dialog.html
+++ b/n26/core/templates/n26/includes/campaign_roll_dialog.html
@@ -1,0 +1,96 @@
+{% comment %}
+One roll question as a panel. Expects `question` (built by
+n26.core.views.campaigns._rolling or _starting and finished by
+_roll_context: kind, title, lead, action, asset_type_id, tables, only,
+chosen, choices), `form` (a RollAssetForm — unbound for a fresh panel, bound
+and carrying the refusal for one drawn again), `campaign` and `redrawn`.
+
+One table offered is not a choice: the panel names it as a settled fact and
+posts it hidden. Several are radio cards, and they stay live whether or not
+a roll is typed, because a manual roll still has to be read against one
+table's rows.
+
+The own-roll field is the form's own, drawn by the form components exactly
+as the campaign budget is. Typing a roll changes the act's name from Roll
+to Use my roll; the sentence under the field says what the selected table's
+die can make, and follows the radio. That is the whole of the script here —
+the server checks the roll against the die regardless, and without a
+script every sentence shows, each naming its die.
+
+The Alpine scope wraps the panel rather than sitting on it: the panel has a
+scope of its own for its open state, and a child scope can read this one,
+so the act's button in the footer and the field in the body share it.
+{% endcomment %}
+{% with chosen=question.chosen %}
+    <div x-data="{ table: '{{ chosen|escapejs }}', rolled: '{{ form.rolled.value|default_if_none:''|escapejs }}' }">
+        <c-n26.dialog title="{{ question.title }}"
+                      action="{{ question.action }}"
+                      cancel_url="{% url 'n26-campaign' campaign.pk %}"
+                      submit_label=""
+                      :redrawn="redrawn"
+                      :htmx="True">
+            <c-slot name="lead">
+                {{ question.lead }}
+            </c-slot>
+            <c-slot name="actions">
+                <c-ui.button type="submit"
+                             variant="success"
+                             x-text="rolled ? 'Use my roll' : 'Roll'">
+                    Roll
+                </c-ui.button>
+            </c-slot>
+            {% csrf_token %}
+            {% for error in form.non_field_errors %}
+                <c-ui.alert variant="error">
+                    {{ error }}
+                </c-ui.alert>
+            {% endfor %}
+            <input type="hidden" name="type" value="{{ question.asset_type_id }}">
+            {% if question.only %}
+                <input type="hidden" name="table" value="{{ question.only.table_id }}">
+                <c-n26.detail-list>
+                    <c-n26.detail-list.row label="Table" :editable="False">
+                        {{ question.only.name }} · {{ question.only.die }}
+                    </c-n26.detail-list.row>
+                </c-n26.detail-list>
+                {# A table posted that is not this one is refused in the form's words. #}
+                <c-ui.error :form="form" name="table" />
+            {% else %}
+                <c-n26.radio-cards label="Table"
+                                   name="table"
+                                   :form="form"
+                                   min="12rem"
+                                   @change="table = $event.target.value">
+                    {% for table, checked in question.choices %}
+                        <c-n26.radio-cards.card name="table"
+                                                value="{{ table.table_id }}"
+                                                label="{{ table.name }}"
+                                                description="{{ table.die }}"
+                                                :checked="checked"
+                                                :wrap="True" />
+                    {% endfor %}
+                </c-n26.radio-cards>
+            {% endif %}
+            <c-ui.field label="{{ form.rolled.label }}"
+                        error="x"
+                        :form="form"
+                        name="rolled"
+                        for="{{ question.kind }}-roll">
+                <c-slot name="description">
+                    {{ form.rolled.help_text }}
+                    {% for table in question.tables %}
+                        <span x-show="table === '{{ table.table_id }}'">A {{ table.die }} roll is {{ table.lowest }} to {{ table.highest }}.</span>
+                    {% endfor %}
+                </c-slot>
+                <c-ui.input id="{{ question.kind }}-roll"
+                            name="rolled"
+                            type="number"
+                            min="1"
+                            inputmode="numeric"
+                            autocomplete="off"
+                            x-model="rolled"
+                            value="{{ form.rolled.value|default_if_none:'' }}" />
+            </c-ui.field>
+        </c-n26.dialog>
+    </div>
+{% endwith %}

--- a/n26/core/templates/n26/includes/campaign_roll_dialogs.html
+++ b/n26/core/templates/n26/includes/campaign_roll_dialogs.html
@@ -1,10 +1,11 @@
 {% comment %}
-The two roll questions the campaign page can ask: Roll territory for the
-campaign's pool when the address names an asset type (`?roll=`), and Roll
-starting territory for one gang when it names a gang and a type
-(`?starting=…&type=…`). Each control takes the asset type's own word, so
+The two roll questions the campaign page can ask: Roll territory to add an
+unclaimed one to the campaign when the address names an asset type
+(`?roll=`), and Roll starting territory for one gang when it names a gang
+and a type (`?starting=…&type=…`). Each takes the asset type's own word, so
 a campaign of Rackets asks to roll a racket. Expects `rolling`, `starting`,
-`campaign` and `redrawn` from the view.
+`form`, `campaign` and `redrawn` from the view; the panel itself is
+campaign_roll_dialog.html.
 
 Drawn inside a host of its own so a click can fetch the question alone: the
 Roll controls ask over htmx, the server sends back this host with the panel
@@ -14,103 +15,27 @@ Fetched on its own the host is swapped in by id, and the panel counts as one
 this page opened, so dismissing it puts the address back rather than
 navigating.
 
-The form posts to the act's own address and the act redirects: what a roll
-adds is a new line in a table, which no partial update can put there.
+The panel posts over htmx. A roll that happens comes back as the page's
+sections redrawn out of band and this host emptied (campaign_update.html);
+a roll refused comes back as this host with the panel open again and the
+reason inside it. Without a script the form posts as any form does and the
+plain campaign page is served.
 
-One table offered is not a choice: the panel names it and posts it hidden.
-Several are cards. Either way the roll may be entered from dice rolled at
-the table, and is otherwise made here.
+A refused roll's panel arrives while the one it replaces is still open,
+under the same id. htmx settles a new element's attributes against the old
+one of that id, which would write the in-flow class back onto the promoted
+modal and leave it at the top left of the page — so the open panel is
+deleted first, by id, and the host then arrives into a page with nothing to
+settle against. Removing an open dialog does not fire its close event, so
+nothing navigates.
 {% endcomment %}
+{% if reopened %}<div id="n26-dialog" hx-swap-oob="delete"></div>{% endif %}
 <div id="n26-roll-dialog-host"
      {% if redrawn %}hx-swap-oob="true"{% endif %}>
     {% if rolling %}
-        <c-n26.dialog title="Roll {{ rolling.label }}"
-                      action="{% url 'n26-campaign-roll-asset' campaign.pk %}"
-                      cancel_url="{% url 'n26-campaign' campaign.pk %}#assets"
-                      submit_label="Roll"
-                      :redrawn="redrawn">
-            <c-slot name="lead">
-                The {{ rolling.label }} the roll lands on is added to the campaign,
-                unclaimed.{% if rolling.to_generate is not None %} The rules generate three per player: {{ rolling.to_generate }} for this campaign.{% endif %}
-            </c-slot>
-            {% csrf_token %}
-            <input type="hidden" name="type" value="{{ rolling.asset_type_id }}">
-            {% if rolling.only %}
-                <input type="hidden" name="table" value="{{ rolling.only.table_id }}">
-                <p class="text-base">
-                    On {{ rolling.only.name }}
-                    <span class="text-muted">({{ rolling.only.die }})</span>
-                </p>
-            {% else %}
-                <c-n26.radio-cards label="Table" name="table" min="12rem">
-                    {% for table in rolling.tables %}
-                        <c-n26.radio-cards.card name="table"
-                                                value="{{ table.table_id }}"
-                                                label="{{ table.name }}"
-                                                description="{{ table.die }}"
-                                                :checked="forloop.first"
-                                                :wrap="True" />
-                    {% endfor %}
-                </c-n26.radio-cards>
-            {% endif %}
-            <c-ui.field label="Enter the roll you made at the table"
-                        description="Optional. Leave blank and the roll is made here."
-                        for="roll-entered">
-                <c-ui.input id="roll-entered"
-                            name="rolled"
-                            type="number"
-                            min="1"
-                            inputmode="numeric"
-                            autocomplete="off"
-                            class="max-w-32" />
-            </c-ui.field>
-        </c-n26.dialog>
+        {% include "n26/includes/campaign_roll_dialog.html" with question=rolling %}
     {% endif %}
     {% if starting %}
-        <c-n26.dialog title="Roll starting {{ starting.label }} for {{ starting.gang_name }}"
-                      action="{% url 'n26-campaign-roll-starting' campaign.pk starting.gang_id %}"
-                      cancel_url="{% url 'n26-campaign' campaign.pk %}#gangs"
-                      submit_label="Roll"
-                      :redrawn="redrawn">
-            <c-slot name="lead">
-                The {{ starting.label }} the roll lands on is assigned to
-                {{ starting.gang_name }}. This roll is separate from the campaign's
-                pool, so it may land on a {{ starting.label }} the pool already has.
-            </c-slot>
-            {% csrf_token %}
-            <input type="hidden" name="type" value="{{ starting.asset_type_id }}">
-            {% if starting.only %}
-                <input type="hidden" name="table" value="{{ starting.only.table_id }}">
-                <p class="text-base">
-                    On {{ starting.only.name }}
-                    <span class="text-muted">({{ starting.only.die }})</span>
-                </p>
-            {% else %}
-                <c-n26.radio-cards label="Table"
-                                   description="The tables {{ starting.gang_name }} holds."
-                                   name="table"
-                                   min="12rem">
-                    {% for table in starting.tables %}
-                        <c-n26.radio-cards.card name="table"
-                                                value="{{ table.table_id }}"
-                                                label="{{ table.name }}"
-                                                description="{{ table.die }}"
-                                                :checked="forloop.first"
-                                                :wrap="True" />
-                    {% endfor %}
-                </c-n26.radio-cards>
-            {% endif %}
-            <c-ui.field label="Enter the roll you made at the table"
-                        description="Optional. Leave blank and the roll is made here."
-                        for="starting-roll-entered">
-                <c-ui.input id="starting-roll-entered"
-                            name="rolled"
-                            type="number"
-                            min="1"
-                            inputmode="numeric"
-                            autocomplete="off"
-                            class="max-w-32" />
-            </c-ui.field>
-        </c-n26.dialog>
+        {% include "n26/includes/campaign_roll_dialog.html" with question=starting %}
     {% endif %}
 </div>

--- a/n26/core/templates/n26/includes/campaign_update.html
+++ b/n26/core/templates/n26/includes/campaign_update.html
@@ -1,0 +1,28 @@
+{% comment %}
+The partial update for a roll on the campaign page — rendered by
+n26.core.views.campaigns._campaign_update, never included by a page.
+
+Nothing here is targeted by the click that caused it. Each host carries
+hx-swap-oob and the id of the element on the page it replaces, so which
+parts of the page a roll updates is decided here and can grow without any
+call site changing. The message is not among them: it rides the HX-Trigger
+header and shows as a toast, because a page that is not re-rendered draws
+no alert block.
+
+Whole sections, never a row. A roll adds a new line — to the assets table,
+to a gang's cell, to the log — and an out-of-band swap can only replace an
+element that is already on the page; it cannot put one where there was
+none. Each host is the same include the page draws, so a section delivered
+by an update and one drawn with the page cannot come to look different.
+
+Expects `sheet` (with its addresses filled), `acts` and `campaign`.
+{% endcomment %}
+{% include "n26/includes/campaign_figures.html" with redrawn=True %}
+{% include "n26/includes/campaign_gangs.html" with redrawn=True %}
+{% include "n26/includes/campaign_assets_section.html" with redrawn=True assets_actions="" %}
+{% include "n26/includes/campaign_log.html" with redrawn=True %}
+{% include "n26/includes/campaign_log_count.html" with redrawn=True %}
+{% comment %}
+The roll dialog's host, emptied: the panel the roll was made from closes.
+{% endcomment %}
+<div id="n26-roll-dialog-host" hx-swap-oob="true"></div>

--- a/n26/core/templates/n26/new_table.html
+++ b/n26/core/templates/n26/new_table.html
@@ -3,8 +3,8 @@
 {% comment %}
 Writing a new asset table into the campaign's own pack, under one of the
 Holding asset types the campaign deals in. The table is built into the
-campaign's own campaign type as it is made, so every gang at the table holds
-it and may roll on it. Its entries are added on the page this lands on.
+campaign's own campaign type as it is made, so every gang in the campaign
+holds it. What it contains is added on the page this lands on.
 Native radios for the asset type and the die, so the form posts with no
 script and a redisplay keeps the pick.
 {% endcomment %}
@@ -19,7 +19,7 @@ script and a redisplay keeps the pick.
 {% block content %}
     <c-n26.form-page action="{% url 'n26-campaign-new-table' campaign.pk %}"
                      title="Create a table"
-                     lead="A table for this campaign alone. Every gang in the campaign may roll on it; no other campaign sees it. You add its entries next."
+                     lead="Give it a name and choose its die. You add what it contains next."
                      :form="form"
                      submit_label="Create table"
                      cancel_url="{{ back }}">
@@ -39,9 +39,9 @@ script and a redisplay keeps the pick.
             </c-ui.breadcrumbs>
         </c-slot>
         {% csrf_token %}
-        <c-n26.form-section title="What it lists">
-            <c-n26.radio-cards label="Asset type *"
-                               description="The table lists assets of this type."
+        <c-n26.form-section title="What it contains">
+            <c-n26.radio-cards label="Asset type"
+                               description="What the table contains."
                                :form="form"
                                name="asset_type">
                 {% for asset_type in asset_types %}
@@ -53,7 +53,7 @@ script and a redisplay keeps the pick.
                 {% endfor %}
             </c-n26.radio-cards>
         </c-n26.form-section>
-        <c-n26.form-section title="The table">
+        <c-n26.form-section title="Name and die">
             <c-ui.field label="Name *" error="x" :form="form" name="name" for="table-name">
                 <c-ui.input id="table-name"
                             name="name"
@@ -61,7 +61,7 @@ script and a redisplay keeps the pick.
                             value="{{ form.name.value|default:'' }}" />
             </c-ui.field>
             <c-n26.radio-cards label="Dice"
-                               description="The die the table is rolled on. Not rolled is an ordered list, chosen from rather than rolled."
+                               description="Choose Not rolled for a plain list."
                                :form="form"
                                name="dice"
                                min="8rem">

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.db.models import Count
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 
 from n26.core.views.permissions import _any_campaign_or_404, _own_campaign_or_404
@@ -190,7 +191,6 @@ def campaign(request, pk):
     """
     from django.urls import reverse
 
-    from n26.core.history import campaign_history, campaign_history_size
     from n26.core.models import CampaignParticipant
     from n26.core.render import render_campaign
     from n26.core.views.htmx import is_htmx
@@ -205,89 +205,22 @@ def campaign(request, pk):
     # ``?starting=`` for one gang — and only the arbitrator's to ask. Over
     # htmx the panel alone is sent, in its host, and the page underneath
     # stays as it is; the address is corrected so a reload draws it again.
-    rolling = _rolling(request, found, sheet) if yours else None
-    starting = _starting(request, found, sheet) if yours and not rolling else None
+    rolling = _rolling(found, sheet, request.GET.get("roll", "")) if yours else None
+    starting = (
+        _starting(sheet, request.GET.get("starting", ""), request.GET.get("type", ""))
+        if yours and not rolling
+        else None
+    )
     if (rolling or starting) and request.method == "GET" and is_htmx(request):
         response = render(
             request,
             "n26/includes/campaign_roll_dialogs.html",
-            {
-                "campaign": found,
-                "rolling": rolling,
-                "starting": starting,
-                "redrawn": True,
-            },
+            _roll_context(found, rolling, starting),
         )
         response["HX-Replace-Url"] = request.get_full_path()
         return response
-    # The addresses are the view's to fill: the structure says who may act,
-    # and only here is it known where each act is asked.
-    here = reverse("n26-campaign", args=[found.pk])
-    for line in sheet.gangs:
-        line.href = reverse("n26-gang", args=[line.gang_id])
-        # The arbitrator may move a campaign counter on any gang at the
-        # table, and a gang's owner their own — the same act the gang sheet
-        # offers, posted from here and landing back here.
-        if yours or line.yours:
-            for counter in line.counters:
-                if counter is not None and counter.assignment_id:
-                    counter.href = reverse("n26-tally", args=[counter.assignment_id])
-                    counter.back = here + "#gangs"
-    if yours:
-        # What the arbitrator adds sits where it will show: an asset type
-        # becomes a table under Assets, a counter or a label becomes a
-        # column of the gangs table.
-        sheet.add_asset_type_href = reverse(
-            "n26-campaign-add-asset-type", args=[found.pk]
-        )
-        sheet.add_counter_href = reverse("n26-campaign-add-counter", args=[found.pk])
-        sheet.add_label_href = reverse("n26-campaign-add-label", args=[found.pk])
-        sheet.tables_href = reverse("n26-campaign-tables", args=[found.pk])
-        # A starting roll is asked on this page, for one gang and one asset
-        # type; the address names both so a reload asks it again.
-        for line in sheet.gangs:
-            for roll in line.starting_rolls:
-                roll.href = f"{here}?starting={line.gang_id}&type={roll.asset_type_id}"
-    for table in sheet.assets:
-        if yours:
-            table.add_href = (
-                reverse("n26-campaign-add-asset", args=[found.pk])
-                + f"?type={table.asset_type_id}"
-            )
-            table.create_href = (
-                reverse("n26-campaign-new-asset", args=[found.pk])
-                + f"?type={table.asset_type_id}"
-            )
-            # Only where there is a rolled table to roll on: a control for
-            # a roll nothing can be rolled on would be a control saying no.
-            if table.tables:
-                table.roll_href = f"{here}?roll={table.asset_type_id}"
-        for entry in table.entries:
-            if entry.held:
-                entry.holder_href = reverse("n26-gang", args=[entry.holder_gang_id])
-            if entry.held and (yours or entry.holder_yours):
-                entry.unassign_href = reverse(
-                    "n26-campaign-asset-unassign",
-                    args=[found.pk, entry.campaign_asset_id],
-                )
-                entry.transfer_href = reverse(
-                    "n26-campaign-asset-transfer",
-                    args=[found.pk, entry.campaign_asset_id],
-                )
-                entry.transfer_label = "Transfer" if yours else "Hand over"
-            if not entry.held and yours:
-                entry.assign_href = reverse(
-                    "n26-campaign-asset-assign",
-                    args=[found.pk, entry.campaign_asset_id],
-                )
-                entry.remove_href = reverse(
-                    "n26-campaign-asset-remove",
-                    args=[found.pk, entry.campaign_asset_id],
-                )
-    # Only the acts that will be drawn are built; how many more there are is
-    # counted rather than read, so a campaign played for a year opens as
-    # quickly as one set up this morning.
-    recent = campaign_history(found, viewer=request.user, limit=LOG_ON_THE_PAGE)
+    _fill_addresses(sheet, found, yours=yours)
+    acts, more_acts = _recent_acts(found, request.user)
     battles = found.battles.prefetch_related("gangs")[:BATTLES_ON_THE_PAGE]
     # Read once and asked twice: the page draws the players, and whether
     # this reader is one of them decides what it offers them.
@@ -309,70 +242,246 @@ def campaign(request, pk):
             "may_add_gang": yours or at_the_table,
             "players": players,
             "battles": battles,
-            "acts": list(reversed(recent)),
-            "more_acts": max(campaign_history_size(found) - len(recent), 0),
-            "rolling": rolling,
-            "starting": starting,
+            "acts": acts,
+            "more_acts": more_acts,
+            **_roll_context(found, rolling, starting, redrawn=False),
         },
     )
 
 
-def _rolling(request, campaign, sheet):
-    """The pool roll ``?roll=`` asks for, where the address names one of
-    the campaign's Holding asset types with a rolled table to roll on.
-    Anything else is a page without the panel."""
+def _fill_addresses(sheet, campaign, *, yours):
+    """Put the addresses on a campaign sheet. The structure says who may
+    act; only the view knows where each act is asked, so the same filling
+    serves the page and the partial update a roll delivers."""
+    from django.urls import reverse
+
+    here = reverse("n26-campaign", args=[campaign.pk])
+    for line in sheet.gangs:
+        line.href = reverse("n26-gang", args=[line.gang_id])
+        # The arbitrator may move a campaign counter on any gang in the
+        # campaign, and a gang's owner their own — the same act the gang
+        # sheet offers, posted from here and landing back here.
+        if yours or line.yours:
+            for counter in line.counters:
+                if counter is not None and counter.assignment_id:
+                    counter.href = reverse("n26-tally", args=[counter.assignment_id])
+                    counter.back = here + "#gangs"
+    if yours:
+        # What the arbitrator adds sits where it will show: an asset type
+        # becomes a table under Assets, a counter or a label becomes a
+        # column of the gangs table.
+        sheet.add_asset_type_href = reverse(
+            "n26-campaign-add-asset-type", args=[campaign.pk]
+        )
+        sheet.add_counter_href = reverse("n26-campaign-add-counter", args=[campaign.pk])
+        sheet.add_label_href = reverse("n26-campaign-add-label", args=[campaign.pk])
+        sheet.tables_href = reverse("n26-campaign-tables", args=[campaign.pk])
+        # A starting roll is asked on this page, for one gang and one asset
+        # type; the address names both so a reload asks it again.
+        for line in sheet.gangs:
+            for roll in line.starting_rolls:
+                roll.href = f"{here}?starting={line.gang_id}&type={roll.asset_type_id}"
+    for table in sheet.assets:
+        if yours:
+            table.add_href = (
+                reverse("n26-campaign-add-asset", args=[campaign.pk])
+                + f"?type={table.asset_type_id}"
+            )
+            table.create_href = (
+                reverse("n26-campaign-new-asset", args=[campaign.pk])
+                + f"?type={table.asset_type_id}"
+            )
+            # Only where there is a rolled table: a control for a roll
+            # with nothing to roll from would be a control saying no.
+            if table.tables:
+                table.roll_href = f"{here}?roll={table.asset_type_id}"
+        for entry in table.entries:
+            if entry.held:
+                entry.holder_href = reverse("n26-gang", args=[entry.holder_gang_id])
+            if entry.held and (yours or entry.holder_yours):
+                entry.unassign_href = reverse(
+                    "n26-campaign-asset-unassign",
+                    args=[campaign.pk, entry.campaign_asset_id],
+                )
+                entry.transfer_href = reverse(
+                    "n26-campaign-asset-transfer",
+                    args=[campaign.pk, entry.campaign_asset_id],
+                )
+                entry.transfer_label = "Transfer" if yours else "Hand over"
+            if not entry.held and yours:
+                entry.assign_href = reverse(
+                    "n26-campaign-asset-assign",
+                    args=[campaign.pk, entry.campaign_asset_id],
+                )
+                entry.remove_href = reverse(
+                    "n26-campaign-asset-remove",
+                    args=[campaign.pk, entry.campaign_asset_id],
+                )
+
+
+def _recent_acts(campaign, viewer):
+    """The acts the campaign page draws, oldest first, and how many more
+    there are. Only the acts that will be drawn are built; the rest are
+    counted rather than read, so a campaign played for a year opens as
+    quickly as one set up this morning."""
+    from n26.core.history import campaign_history, campaign_history_size
+
+    recent = campaign_history(campaign, viewer=viewer, limit=LOG_ON_THE_PAGE)
+    more = max(campaign_history_size(campaign) - len(recent), 0)
+    return list(reversed(recent)), more
+
+
+def _rolling(campaign, sheet, asked):
+    """The pool roll ``?roll=`` asks for, where ``asked`` names one of the
+    campaign's Holding asset types with a rolled table. Anything else is
+    a page without the panel."""
+    from django.urls import reverse
+
     from n26.library.territory_table import TERRITORY
 
-    asked = request.GET.get("roll", "")
     table = next((t for t in sheet.assets if t.asset_type_id == asked), None)
     if table is None or not table.tables:
         return None
     # Three per player is the rulebook's figure for Territories. An asset
     # type the arbitrator declared has no such rule, so its dialog says
     # nothing about how many to generate.
-    territories = table.label == TERRITORY
+    label = table.label.lower()
+    lead = f"The rolled {label} will be added to the campaign as unclaimed."
+    if table.label == TERRITORY:
+        lead += (
+            " The rules generate three per player: "
+            f"{sheet.territories_to_generate} for this campaign."
+        )
     return {
+        "kind": "pool",
+        "title": f"Roll {label}",
+        "lead": lead,
+        "action": reverse("n26-campaign-roll-asset", args=[campaign.pk]),
         "asset_type_id": asked,
-        "label": table.label.lower(),
+        "label": label,
         "tables": table.tables,
         "only": table.tables[0] if len(table.tables) == 1 else None,
-        "to_generate": sheet.territories_to_generate if territories else None,
     }
 
 
-def _starting(request, campaign, sheet):
-    """The starting roll ``?starting=`` asks for: one gang at the table,
-    and an asset type of which it holds a rolled table. Anything else is
-    a page without the panel."""
-    gang_id = request.GET.get("starting", "")
-    asked = request.GET.get("type", "")
+def _starting(sheet, gang_id, asked):
+    """The starting roll ``?starting=`` asks for: one gang in the
+    campaign, and an asset type of which it holds a rolled table.
+    Anything else is a page without the panel."""
+    from django.urls import reverse
+
     line = next((g for g in sheet.gangs if g.gang_id == gang_id), None)
     if line is None:
         return None
     roll = next((r for r in line.starting_rolls if r.asset_type_id == asked), None)
     if roll is None:
         return None
+    # The type's own word, off the sheet's columns rather than peeled off
+    # the control's wording, so a change to the button cannot reach here.
+    label = next(
+        column.label.lower()
+        for column in sheet.asset_types
+        if column.asset_type_id == asked
+    )
     return {
+        "kind": "starting",
+        "title": f"Roll starting {label} for {line.name}",
+        "lead": f"The rolled {label} will be assigned to {line.name}.",
+        "action": reverse(
+            "n26-campaign-roll-starting", args=[sheet.campaign_id, gang_id]
+        ),
         "gang_id": gang_id,
         "gang_name": line.name,
         "asset_type_id": asked,
-        "label": roll.label.removeprefix("Roll starting "),
+        "label": label,
         "tables": roll.tables,
         "only": roll.tables[0] if len(roll.tables) == 1 else None,
     }
 
 
+def _roll_context(campaign, rolling, starting, form=None, *, redrawn=True):
+    """What the roll dialogs template draws from: the open question, its
+    form, and which table its cards show as chosen.
+
+    ``form`` is the bound form carrying a refusal, for a dialog drawn
+    again; without one the form is fresh, over the tables the dialog
+    offers. The chosen table is the one the form was posted with, or the
+    first offered — decided here rather than in the template, which
+    cannot compare two values inside a component's attribute. A posted
+    value that is not one of the tables offered falls back to the first,
+    so the cards still show one chosen and the script reads a known id.
+    """
+    from n26.core.forms import RollAssetForm
+    from n26.library.models import AssetTable
+
+    question = rolling or starting
+    if question is not None:
+        tables = question["tables"]
+        if form is None:
+            form = RollAssetForm(
+                tables=AssetTable.objects.filter(pk__in=[t.table_id for t in tables])
+            )
+        chosen = str(form["table"].value() or "")
+        if chosen not in {table.table_id for table in tables}:
+            chosen = tables[0].table_id
+        question["chosen"] = chosen
+        question["choices"] = [(table, table.table_id == chosen) for table in tables]
+    return {
+        "campaign": campaign,
+        "rolling": rolling,
+        "starting": starting,
+        "form": form,
+        "redrawn": redrawn,
+        # A dialog drawn again after a refusal replaces one still open.
+        "reopened": redrawn and form is not None and form.is_bound,
+    }
+
+
+def _roll_dialog(request, campaign, rolling, starting, form):
+    """A refused roll's dialog on its own, in its host, for a page that is
+    not rebuilt: drawn open again with the refusal inside it. ``form`` is
+    the bound form carrying the refusal."""
+    return render(
+        request,
+        "n26/includes/campaign_roll_dialogs.html",
+        _roll_context(campaign, rolling, starting, form),
+    )
+
+
+def _campaign_update(request, campaign):
+    """What a roll changed on the campaign page, delivered out of band:
+    the figures, the gangs table, the assets section and the log, each
+    redrawn whole from a fresh sheet, plus the dialog host emptied so the
+    panel closes. Whole sections rather than a row, because what a roll
+    adds is a new line, and no partial update can put one where there
+    was none. The address goes back to the plain campaign page, and the
+    queued message rides along as a toast."""
+    from n26.core.render import render_campaign
+    from n26.core.views.htmx import with_toasts
+
+    sheet = render_campaign(campaign, viewer=request.user)
+    _fill_addresses(sheet, campaign, yours=True)
+    acts, more_acts = _recent_acts(campaign, request.user)
+    response = render(
+        request,
+        "n26/includes/campaign_update.html",
+        {"campaign": campaign, "sheet": sheet, "acts": acts, "more_acts": more_acts},
+    )
+    response["HX-Replace-Url"] = _campaign_page(campaign)
+    return with_toasts(request, response)
+
+
 @requires_flag(CAMPAIGNS)
 @login_required
 def roll_asset(request, pk):
-    """Roll on one of the campaign's tables for its pool: the act behind
-    the ``?roll=`` dialog.
+    """Roll from one of the campaign's tables to add an unclaimed asset:
+    the act behind the ``?roll=`` dialog.
 
     The tables accepted are the rolled ones the campaign itself holds of
     the asset type named, the same list the dialog offered. A refusal in
-    words lands as a message and the dialog opens again; the roll lands
-    the reader back at the assets, where what it added now stands. GET
-    reopens the dialog instead of acting.
+    words is drawn into the dialog; a roll that happens updates the page
+    in place over htmx, and serves the plain campaign page without it.
+    GET reopens the dialog instead of acting.
     """
     from n26.core.campaigns import campaign_operation, tables_in_play
     from n26.core.forms import RollAssetForm
@@ -390,35 +499,77 @@ def roll_asset(request, pk):
         .exclude(dice="")
     )
     form = RollAssetForm(request.POST, tables=tables)
-    if not form.is_valid():
-        messages.error(request, _first_error(form))
-        return redirect(again)
-    try:
-        with campaign_operation(found, actor=request.user) as act:
-            roll = act.roll_asset(
-                form.cleaned_data["table"], rolled=form.cleaned_data["rolled"]
-            )
-    except Refusal as refused:
-        messages.error(request, str(refused))
-        return redirect(again)
+    roll = None
+    if form.is_valid():
+        try:
+            with campaign_operation(found, actor=request.user) as act:
+                roll = act.roll_asset(
+                    form.cleaned_data["table"], rolled=form.cleaned_data["rolled"]
+                )
+        except Refusal as refused:
+            form.add_error(None, str(refused))
+    if roll is None:
+        return _roll_refused(
+            request,
+            found,
+            form,
+            again,
+            lambda sheet: _rolling(found, sheet, str(asset_type.pk)),
+        )
     messages.success(
         request,
-        f"Rolled {roll.roll} on {roll.table}: {roll.campaign_asset} added to the "
-        "campaign, unclaimed.",
+        f"Rolled {roll.roll}: {roll.campaign_asset} added to the campaign, unclaimed.",
     )
-    return redirect(_assets_anchor(found))
+    return _roll_made(request, found)
+
+
+def _roll_refused(request, campaign, form, again, question):
+    """A roll that did not happen — the form did not hold up, or the
+    operation refused it in words. Over htmx the dialog is drawn back
+    into its host, open, with the reason inside it, and nothing else on
+    the page moves; without htmx the reason is queued and the page with
+    the dialog open is served again. ``question`` builds the dialog's
+    facts from a fresh sheet."""
+    from n26.core.render import render_campaign
+    from n26.core.views.htmx import is_htmx
+
+    if not is_htmx(request):
+        messages.error(request, _first_error(form))
+        return redirect(again)
+    sheet = render_campaign(campaign, viewer=request.user)
+    asked = question(sheet)
+    if asked is None:
+        # The dialog no longer has anything to offer — the table was
+        # withdrawn since it was drawn. The page is the only answer.
+        response = HttpResponse(status=204)
+        response["HX-Redirect"] = _campaign_page(campaign)
+        return response
+    if "gang_id" in asked:
+        return _roll_dialog(request, campaign, None, asked, form=form)
+    return _roll_dialog(request, campaign, asked, None, form=form)
+
+
+def _roll_made(request, campaign):
+    """A roll that happened. Over htmx the page is updated in place and
+    the message shows as a toast; without htmx the plain campaign page
+    is served, with no anchor, so the message at its top is seen."""
+    from n26.core.views.htmx import is_htmx
+
+    if is_htmx(request):
+        return _campaign_update(request, campaign)
+    return redirect(_campaign_page(campaign))
 
 
 @requires_flag(CAMPAIGNS)
 @login_required
 def roll_starting_asset(request, pk, gang_pk):
-    """Roll one gang's starting asset on a table it holds: the act behind
-    the ``?starting=`` dialog.
+    """Roll one gang's starting asset from a table it holds: the act
+    behind the ``?starting=`` dialog.
 
     The tables accepted are the rolled ones that gang holds of the asset
     type named — stored or granted, the same list the dialog offered. The
-    asset lands assigned to the gang, and the reader back at the gangs
-    table, where the gang's line now names it.
+    asset lands assigned to the gang, and the gangs table redrawn names it
+    on the gang's line.
     """
     from django.core.exceptions import ValidationError
     from django.http import Http404
@@ -458,25 +609,30 @@ def roll_starting_asset(request, pk, gang_pk):
         if table.dice and table.asset_type_id == asset_type.pk
     ]
     form = RollAssetForm(request.POST, tables=AssetTable.objects.filter(pk__in=held))
-    if not form.is_valid():
-        messages.error(request, _first_error(form))
-        return redirect(again)
-    try:
-        with campaign_operation(found, actor=request.user) as act:
-            roll = act.roll_asset(
-                form.cleaned_data["table"],
-                membership=membership,
-                rolled=form.cleaned_data["rolled"],
-            )
-    except Refusal as refused:
-        messages.error(request, str(refused))
-        return redirect(again)
+    roll = None
+    if form.is_valid():
+        try:
+            with campaign_operation(found, actor=request.user) as act:
+                roll = act.roll_asset(
+                    form.cleaned_data["table"],
+                    membership=membership,
+                    rolled=form.cleaned_data["rolled"],
+                )
+        except Refusal as refused:
+            form.add_error(None, str(refused))
+    if roll is None:
+        return _roll_refused(
+            request,
+            found,
+            form,
+            again,
+            lambda sheet: _starting(sheet, str(gang_pk), str(asset_type.pk)),
+        )
     messages.success(
         request,
-        f"Rolled {roll.roll} on {roll.table} for {membership.gang.name}: "
-        f"{roll.campaign_asset}.",
+        f"Rolled {roll.roll}: {roll.campaign_asset} assigned to {membership.gang.name}.",
     )
-    return redirect(_gangs_anchor(found))
+    return _roll_made(request, found)
 
 
 def _campaign_page(campaign):
@@ -1472,15 +1628,32 @@ def _open_tables(campaign):
 
 
 def _table_said(table):
-    """One table's facts under its name: the die and how many entries."""
-    die = f"rolled on a {table.get_dice_display()}" if table.dice else "not rolled"
+    """One table's facts under its name: its die, and how many of the
+    asset type it contains, in the type's own word — "D66 · 18
+    territories". An unrolled table says only what it contains."""
+    asset_type = table.asset_type
     count = table.entry_count
-    entries = (
-        "no entries yet"
-        if count == 0
-        else f"{count} entr{'y' if count == 1 else 'ies'}"
-    )
-    return f"{die} · {entries}"
+    if count == 0:
+        contains = f"no {asset_type.plural.lower()} yet"
+    elif count == 1:
+        contains = f"1 {asset_type.label_singular.lower()}"
+    else:
+        contains = f"{count} {asset_type.plural.lower()}"
+    if table.dice:
+        return f"{table.get_dice_display()} · {contains}"
+    return contains
+
+
+def _tables_lead(asset_types):
+    """The Tables page's lead, in the one word where the campaign has one
+    Holding asset type and it is Territory — the common case — and in
+    general words otherwise."""
+    from n26.library.territory_table import TERRITORY
+
+    holding = [t for t in asset_types if t.is_holding]
+    if len(holding) == 1 and holding[0].label_singular == TERRITORY:
+        return "Tables of territories the gangs in this campaign can use."
+    return "Tables the gangs in this campaign can use."
 
 
 @requires_flag(CAMPAIGNS)
@@ -1526,22 +1699,39 @@ def campaign_tables(request, pk):
             else:
                 said = []
                 if opened:
-                    said.append(f"Opened {', '.join(opened)} to every gang.")
+                    said.append(f"Made {', '.join(opened)} available to every gang.")
                 if closed:
-                    said.append(f"Closed {', '.join(closed)}.")
+                    said.append(f"Withdrew {', '.join(closed)}.")
                 messages.success(request, " ".join(said) or "Nothing changed.")
             return redirect("n26-campaign-tables", pk=found.pk)
         messages.error(request, _first_error(form))
         return redirect("n26-campaign-tables", pk=found.pk)
 
+    asset_types = list(_campaign_asset_types(found))
     sections = []
-    for asset_type in _campaign_asset_types(found):
+    for asset_type in asset_types:
         if not asset_type.is_holding:
             continue
         tables = [t for t in offered if t.asset_type_id == asset_type.pk]
+        label = asset_type.label_singular.lower()
+        plural = asset_type.plural.lower()
         sections.append(
             {
                 "asset_type": asset_type,
+                "label": label,
+                "plural": plural,
+                "intro": (
+                    f"Gangs can roll for a starting {label} from any of these. "
+                    f"You can also roll to add unclaimed {plural} to the campaign."
+                ),
+                "ticks_help": (
+                    "Tick a table to make it available to every gang. Untick to "
+                    f"withdraw it. {asset_type.plural} already rolled stay in the "
+                    "campaign."
+                ),
+                "empty": (
+                    f"No tables of {plural} yet. Create one and add {plural} to it."
+                ),
                 "given": [
                     {
                         "name": str(t),
@@ -1572,6 +1762,7 @@ def campaign_tables(request, pk):
         {
             "campaign": found,
             "sections": sections,
+            "lead": _tables_lead(asset_types),
             "back": _assets_anchor(found),
             "new_href": reverse("n26-campaign-new-table", args=[found.pk]),
         },
@@ -1617,8 +1808,8 @@ def new_table(request, pk):
         else:
             messages.success(
                 request,
-                f"Created the table {table}. Every gang in the campaign may roll "
-                "on it once it has entries.",
+                f"Created the table {table}. Add "
+                f"{table.asset_type.plural.lower()} to it next.",
             )
             return redirect("n26-campaign-table", pk=found.pk, table_pk=table.pk)
 
@@ -1747,6 +1938,8 @@ def campaign_table(request, pk, table_pk):
                 }
                 for asset in offered
             ],
+            "label": table.asset_type.label_singular.lower(),
+            "plural": table.asset_type.plural.lower(),
             "back": reverse("n26-campaign-tables", args=[found.pk]),
         },
     )

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -492,7 +492,7 @@ def roll_asset(request, pk):
     asset_type = _asset_type_asked_for(found, asked)
     again = _campaign_page(found) + (f"?roll={asset_type.pk}" if asset_type else "")
     if request.method != "POST" or asset_type is None:
-        return redirect(again)
+        return _back_to_the_page(request, again)
     tables = (
         tables_in_play(found, include_staged=sees_staged(request.user))
         .filter(asset_type=asset_type)
@@ -521,6 +521,19 @@ def roll_asset(request, pk):
         f"Rolled {roll.roll}: {roll.campaign_asset} added to the campaign, unclaimed.",
     )
     return _roll_made(request, found)
+
+
+def _back_to_the_page(request, again):
+    """Leave a roll dialog for the page itself: a plain redirect, or over
+    htmx — where a redirect's body would be swallowed by ``hx-swap="none"``
+    and nothing would move — an ``HX-Redirect`` the browser follows."""
+    from n26.core.views.htmx import is_htmx
+
+    if not is_htmx(request):
+        return redirect(again)
+    response = HttpResponse(status=204)
+    response["HX-Redirect"] = again
+    return response
 
 
 def _roll_refused(request, campaign, form, again, question):
@@ -600,7 +613,7 @@ def roll_starting_asset(request, pk, gang_pk):
         f"?starting={gang_pk}&type={asset_type.pk}" if asset_type else ""
     )
     if request.method != "POST" or asset_type is None:
-        return redirect(again)
+        return _back_to_the_page(request, again)
     held = [
         table.pk
         for table in tables_held_by(

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -212,7 +212,7 @@ def _roll_result(event, found, offer, *, include_staged=False):
     from django.db.models import F
 
     from n26.core.browse import picklist_lines
-    from n26.core.operations import ROLL_ENTERED
+    from n26.core.operations import ROLL_ENTERED, ROLL_ENTERED_BEFORE
     from n26.core.render import RollResult, option_key
     from n26.library.models import Dice, RollSelects
 
@@ -244,7 +244,7 @@ def _roll_result(event, found, offer, *, include_staged=False):
         dice_label=dice.label,
         faces=Dice.faces(dice, event.roll),
         landed=tuple(named.get(option_key(m.pickable), m.label) for m in landed),
-        entered=event.note == ROLL_ENTERED,
+        entered=event.note in (ROLL_ENTERED, ROLL_ENTERED_BEFORE),
         applied=str(spent.assignable) if spent is not None else "",
         threshold=picklist.roll_selects == RollSelects.THRESHOLD,
     )

--- a/n26/library/models/modifier.py
+++ b/n26/library/models/modifier.py
@@ -806,8 +806,8 @@ class TargetsGang(models.Model):
     all-models reach.
 
     Narrowing is done by **condition rows** hanging off this scope, as
-    on the model scope: ``GangHasPickable`` for "gangs that have picked
-    Goliath". With no rows it reaches the gang, whatever the gang has
+    on the model scope: ``GangHasPickable`` for "Goliath gangs". With no
+    rows it reaches the gang, whatever the gang has
     picked. The rows are read against the gang's own facts — its
     assignments, and the picks it was given — so a boon for Goliath
     gangs reaches a Goliath gang and a Clan House Goliath Outcast gang
@@ -935,9 +935,10 @@ class TargetsGang(models.Model):
 class GangHasPickable(models.Model):
     """Condition: the gang has one of these picked.
 
-    "Gangs that have picked Goliath" — the shape of a boon that applies
-    only to some gangs. Any-of within the row; negated, it is every
-    gang except those.
+    "Goliath gangs" — the shape of a boon that applies only to some
+    gangs. Any-of within the row; negated, it is every gang except
+    those. Written as the pick's name alone: nobody picks a supertype,
+    so the wording never uses "picked".
 
     What was picked is an ordinary assignment the gang holds, or a pick
     given to it with a hidden slot, so one condition serves every slot
@@ -963,9 +964,11 @@ class GangHasPickable(models.Model):
 
     def __str__(self):
         wanted = list(self.pickables.all()) if self.pk else []
+        if not wanted:
+            return "every gang"
         if self.negate:
-            return "every gang except those that have picked " + _some_of(wanted)
-        return "gangs that have picked " + _some_of(wanted)
+            return f"every gang except {_some_of(wanted)} gangs"
+        return f"{_some_of(wanted)} gangs"
 
     def as_condition(self):
         from n26.core import select

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -845,10 +845,9 @@ def _narrowed_gang(who, scope):
 
     There is one gang, so nothing qualifies the subject: the renderers
     say "the gang" and go on saying it. What a condition adds is the
-    gang it has to be — "for gangs that have picked Goliath, the gang
-    gains …" — said in the condition row's own words, so the modifier's
-    auto-name and this sentence cannot come to describe the gangs
-    differently.
+    gang it has to be — "for Goliath gangs, the gang gains …" — said in
+    the condition row's own words, so the modifier's auto-name and this
+    sentence cannot come to describe the gangs differently.
     """
     rows = scope._narrowing_rows()
     if not rows:

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -570,8 +570,8 @@ def _build_registry():
             label="The gang carrying it and all models",
             blurb=(
                 "Affects the gang and all models, in a different way per "
-                "effect. Use with care. A condition can narrow it to gangs "
-                "that have picked a particular pickable."
+                "effect. Use with care. A condition can narrow it to the "
+                "gangs of one pick — Goliath gangs."
             ),
             example=(
                 "A rule given to the gang prints on the gang's sheet only, "
@@ -588,14 +588,13 @@ def _build_registry():
             blurb=(
                 "Applied only to the gang; does not reach the models. A pick "
                 "given with a slot is still a fact about every model in the "
-                "gang. A condition can narrow it to gangs that have picked a "
-                "particular pickable."
+                "gang. A condition can narrow it to the gangs of one pick — "
+                "Goliath gangs."
             ),
             example=(
                 "A rule that prints on the gang sheet without touching the "
-                "fighters, or a gang-level counter. A territory boon for "
-                "Goliath gangs: gangs that have picked Goliath add 10 to "
-                "Income."
+                "fighters, or a gang-level counter. A territory boon that "
+                "reads Goliath gangs: +10 Income."
             ),
         ),
         # -- effects, worked out at read time --------------------------

--- a/n26/tests/sandbox/test_asset_rolls.py
+++ b/n26/tests/sandbox/test_asset_rolls.py
@@ -24,7 +24,9 @@ and the campaign page costs the same however many gangs and tables it
 has.
 """
 
+import json
 import random
+import re
 
 import pytest
 from django.apps import apps
@@ -229,11 +231,11 @@ class TestThePoolRoll:
         assert roll.dice.label == "D66"
         (event,) = rolled_events(campaign)
         assert event.note == (
-            f"Rolled {roll.roll} on the Territory Selection Table: {kept.asset.name}."
+            f"Rolled {roll.roll} from the Territory Selection Table: {kept.asset.name}."
         )
         assert not campaign.events.filter(kind=CampaignEvent.Kind.ASSET_ADDED).exists()
         assert sentences(campaign_history(campaign))[-1] == (
-            f"rolled {roll.roll} on the Territory Selection Table: {kept.asset.name}"
+            f"rolled {roll.roll} from the Territory Selection Table: {kept.asset.name}"
         )
         assert campaign_history(campaign)[-1].actor == "arbitrator"
 
@@ -245,12 +247,37 @@ class TestThePoolRoll:
         assert roll.roll == 34
         assert roll.campaign_asset.asset.name == "Corpse Farm"
         (event,) = rolled_events(campaign)
+        assert ROLL_ENTERED == "Manual roll."
         assert event.note == (
-            f"Rolled 34 on the Territory Selection Table: Corpse Farm. {ROLL_ENTERED}"
+            f"Rolled 34 from the Territory Selection Table: Corpse Farm. {ROLL_ENTERED}"
         )
         assert sentences(campaign_history(campaign))[-1] == (
-            "rolled 34 on the Territory Selection Table: Corpse Farm, entered "
-            "from a roll at the table"
+            "rolled 34 from the Territory Selection Table: Corpse Farm (manual roll)"
+        )
+
+    def test_a_stop_inside_a_name_does_not_cut_the_log_line(
+        self, campaign, territory, goliath, owner
+    ):
+        """The manual-roll marker is taken off the note by name, so a gang
+        or a table with a full stop in its own name keeps its whole line."""
+        # The table first, so the gang holds it as it joins.
+        table = create_campaign_table(campaign, territory, "No. 2 Turf", dice="d3")
+        ruins = _holding_assets(campaign).get(name="Old Ruins")
+        add_asset_table_entry(table, ruins, roll_low=1, roll_high=3)
+        doc = found_gang("Dr. Skabb's Crew", goliath, owner=owner, budget=1000)
+        join_campaign(doc, campaign)
+
+        roll_asset(campaign, table, gang=doc, rolled=2)
+        roll_asset(campaign, table, gang=doc)
+        lines = sentences(campaign_history(campaign))
+        assert (
+            "rolled 2 from No. 2 Turf for Dr. Skabb's Crew: Old Ruins (manual roll)"
+            in lines
+        )
+        assert any(
+            line.startswith("rolled ")
+            and line.endswith("from No. 2 Turf for Dr. Skabb's Crew: Old Ruins")
+            for line in lines
         )
 
     def test_a_staged_entry_is_a_gap_for_a_reader_who_may_not_see_it(
@@ -302,13 +329,15 @@ class TestThePoolRoll:
             roll_high=3,
         )
 
-        with pytest.raises(Refusal, match="No entry on Holed covers a roll of 5"):
+        with pytest.raises(Refusal, match="Nothing on Holed covers a roll of 5"):
             roll_asset(campaign, holed, rolled=5)
         assert roll_asset(campaign, holed, rolled=2).campaign_asset.asset.name == "Sump"
 
     def test_a_list_without_dice_is_refused(self, campaign, territory):
         listed = create_campaign_table(campaign, territory, "Listed")
-        with pytest.raises(Refusal, match="It has no dice"):
+        with pytest.raises(
+            Refusal, match="Listed cannot be rolled. It is a list with no dice."
+        ):
             roll_asset(campaign, listed)
 
     def test_a_table_the_campaign_does_not_hold_is_refused(
@@ -323,7 +352,7 @@ class TestThePoolRoll:
             elsewhere, create_asset("Yard", turf), roll_low=1, roll_high=6
         )
 
-        with pytest.raises(Refusal, match="Only a table built into the campaign"):
+        with pytest.raises(Refusal, match="Elsewhere is not available to Dust Falls."):
             roll_asset(campaign, elsewhere, rolled=3)
         assert list(tables_in_play(campaign)) == [AssetTable.objects.get(name=TABLE)]
 
@@ -352,7 +381,7 @@ class TestTheStartingRoll:
         assert gained.campaign_asset == kept
         (event,) = rolled_events(campaign)
         assert event.note == (
-            f"Rolled 1 on Goliath Territories for Slag Kings: Amneo-vats. {ROLL_ENTERED}"
+            f"Rolled 1 from Goliath Territories for Slag Kings: Amneo-vats. {ROLL_ENTERED}"
         )
         slag_kings.refresh_from_db()
         assert slag_kings.rating == 0
@@ -364,8 +393,8 @@ class TestTheStartingRoll:
         assert journal not in tables_held_by(wild_cats, campaign)
         with pytest.raises(
             Refusal,
-            match="Wild Cats cannot roll on Goliath Territories. Only a gang that "
-            "holds that table can.",
+            match="Wild Cats cannot roll for a territory from Goliath Territories. "
+            "That table is not available to Wild Cats.",
         ):
             roll_asset(campaign, journal, gang=wild_cats, rolled=2)
 
@@ -379,22 +408,21 @@ class TestTheStartingRoll:
         roll = roll_asset(campaign, journal, gang=wild_cats, rolled=2)
         assert roll.campaign_asset.asset.name == "Slag Furnace"
         assert sentences(campaign_history(campaign))[-3:] == [
-            "opened the table Goliath Territories to every gang",
-            "rolled 2 on Goliath Territories for Wild Cats: Slag Furnace, entered "
-            "from a roll at the table",
+            "made the table Goliath Territories available to every gang",
+            "rolled 2 from Goliath Territories for Wild Cats: Slag Furnace (manual roll)",
             "Slag Furnace went to Wild Cats",
         ]
 
         close_table(campaign, journal)
 
         assert journal not in tables_held_by(wild_cats, campaign)
-        with pytest.raises(Refusal, match="Wild Cats cannot roll on"):
+        with pytest.raises(Refusal, match="Wild Cats cannot roll for"):
             roll_asset(campaign, journal, gang=wild_cats, rolled=3)
         # Nothing taken back: the territory it rolled is still held.
         roll.campaign_asset.refresh_from_db()
         assert roll.campaign_asset.holder.gang == wild_cats
         assert sentences(campaign_history(campaign))[-1] == (
-            "closed the table Goliath Territories"
+            "withdrew the table Goliath Territories"
         )
         wild_cats.refresh_from_db()
         assert_reconciled(wild_cats)
@@ -493,7 +521,7 @@ class TestTheCatalogue:
         self, campaign, selection_table
     ):
         assert open_table(campaign, selection_table) is None
-        with pytest.raises(Refusal, match="gives it to every gang"):
+        with pytest.raises(Refusal, match="It is included with Territory campaign"):
             close_table(campaign, selection_table)
         assert list(tables_in_play(campaign)) == [selection_table]
 
@@ -659,7 +687,7 @@ class TestThePages:
             reverse("n26-campaign", args=[quiet.pk]) + f"?roll={racket.pk}"
         ).content.decode()
         assert "Roll racket" in page
-        assert "The racket the roll lands on is added" in page
+        assert "The rolled racket will be added to the campaign as unclaimed." in page
         assert "three per player" not in page
 
     def test_a_malformed_gang_key_is_a_bad_link(
@@ -703,8 +731,6 @@ class TestThePages:
         page = client.get(address).content.decode()
         assert "The rules generate three per player: 6 for this campaign." in page
         assert "Roll territory" in page
-        # One table: named, not chosen.
-        assert "On Territory Selection Table" in page
         assert f'name="table" value="{selection_table.pk}"' in page
 
         # Over htmx the panel alone comes back, in its host.
@@ -714,6 +740,14 @@ class TestThePages:
         assert "hx-swap-oob" in body
         assert "<c-n26.view" not in body and "Gangs" not in body
         assert partial["HX-Replace-Url"] == address
+        # One table is a fact, not a choice: named with its die, no radio,
+        # and posted hidden.
+        assert 'type="radio"' not in body
+        assert "Territory Selection Table · D66" in body
+        assert f'type="hidden" name="table" value="{selection_table.pk}"' in body
+        assert (
+            "The rolled territory will be added to the campaign as unclaimed." in body
+        )
 
     def test_the_starting_dialog_offers_only_the_tables_the_gang_holds(
         self, client, campaign, territory, journal, slag_kings, wild_cats, arbitrator
@@ -732,7 +766,38 @@ class TestThePages:
         ).content.decode()
         assert "Roll starting territory for Wild Cats" in cats
         assert "Goliath Territories" not in cats
-        assert "On Territory Selection Table" in cats
+        assert "Territory Selection Table · D66" in cats
+        assert 'type="radio"' not in cats.split('id="n26-roll-dialog-host"')[1]
+        assert "The rolled territory will be assigned to Wild Cats." in cats
+        assert "The tables Wild Cats holds" not in cats
+
+        # Two tables are radio cards, each named with its die; the range
+        # sentence under the own-roll field follows the selected one.
+        assert kings.count('type="radio"') == 2
+        assert "A D6 roll is 1 to 6." in kings
+        assert "A D66 roll is 11 to 66." in kings
+        assert "The rolled territory will be assigned to Slag Kings." in kings
+
+    def test_the_own_roll_field_is_the_forms_drawn_by_the_component(
+        self, client, campaign, territory, selection_table, arbitrator
+    ):
+        """The field is RollAssetForm.rolled through the kit's field and
+        input components — the same drawing as the campaign budget — so
+        it carries the component's border and background classes rather
+        than a hand-written class that would replace them and leave the
+        box invisible in dark mode."""
+        client.force_login(arbitrator)
+        address = reverse("n26-campaign", args=[campaign.pk]) + f"?roll={territory.pk}"
+        body = client.get(address, HTTP_HX_REQUEST="true").content.decode()
+        (widget,) = re.findall(r"<input[^>]*name=\"rolled\"[^>]*>", body)
+        assert "rounded-control" in widget and "border-ink-300" in widget
+        assert "max-w-32" not in widget
+        assert 'type="number"' in widget and 'id="pool-roll"' in widget
+        assert "Your own roll" in body
+        assert "Optional. Leave blank and the roll is made for you." in body
+        assert "A D66 roll is 11 to 66." in body
+        assert "Use my roll" in body
+        assert "at the table" not in body
 
     def test_posting_the_rolls(
         self,
@@ -753,19 +818,25 @@ class TestThePages:
                 "rolled": "63",
             },
         )
+        # Without htmx the plain campaign page, no anchor: the message at
+        # its top is what the reader should see, not the gangs table.
         assert response.status_code == 302
-        assert response["Location"].endswith("#assets")
+        assert response["Location"] == reverse("n26-campaign", args=[campaign.pk])
         (kept,) = CampaignAsset.objects.filter(campaign=campaign)
         assert kept.asset.name == "Old Ruins" and kept.holder is None
+        page = client.get(response["Location"]).content.decode()
+        assert "Rolled 63: Old Ruins added to the campaign, unclaimed." in page
 
         response = client.post(
             reverse("n26-campaign-roll-starting", args=[campaign.pk, slag_kings.pk]),
             {"type": str(territory.pk), "table": str(journal.pk), "rolled": "4"},
         )
         assert response.status_code == 302
-        assert response["Location"].endswith("#gangs")
+        assert response["Location"] == reverse("n26-campaign", args=[campaign.pk])
         held = CampaignAsset.objects.get(campaign=campaign, holder__gang=slag_kings)
         assert held.asset.name == "Iron Forge"
+        page = client.get(response["Location"]).content.decode()
+        assert "Rolled 4: Iron Forge assigned to Slag Kings." in page
 
         # A roll the die cannot make comes back to the dialog with the reason.
         response = client.post(
@@ -797,6 +868,154 @@ class TestThePages:
         assert response.status_code == 200
         assert "You cannot roll 99999 on a D6." in response.content.decode()
         assert not AssetTableEntry.objects.filter(table=turf).exists()
+
+    def test_a_roll_over_htmx_redraws_the_page_in_place_with_a_toast(
+        self,
+        client,
+        campaign,
+        territory,
+        journal,
+        selection_table,
+        slag_kings,
+        arbitrator,
+    ):
+        """The dialog posts over htmx. What comes back is the changed
+        sections out of band — figures, gangs, assets, log — the dialog
+        host emptied, the address put back to the plain page, and the
+        message as a toast. No redirect, no reload, no scroll."""
+        client.force_login(arbitrator)
+        response = client.post(
+            reverse("n26-campaign-roll-asset", args=[campaign.pk]),
+            {
+                "type": str(territory.pk),
+                "table": str(selection_table.pk),
+                "rolled": "63",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+        assert response.status_code == 200
+        assert "Location" not in response
+        body = response.content.decode()
+        for host in (
+            "n26-campaign-figures",
+            "n26-campaign-gangs",
+            "n26-campaign-assets",
+            "n26-campaign-log",
+            "n26-campaign-log-count",
+        ):
+            assert re.search(rf'id="{host}"\s+hx-swap-oob="true"', body), host
+        assert '<div id="n26-roll-dialog-host" hx-swap-oob="true"></div>' in body
+        assert "<dialog" not in body
+        # The sections carry what the roll changed.
+        assert "Old Ruins" in body
+        assert (
+            "rolled 63 from the Territory Selection Table: Old Ruins (manual roll)"
+            in body
+        )
+        assert "1 unclaimed" in body
+        assert response["HX-Replace-Url"] == reverse("n26-campaign", args=[campaign.pk])
+        toasts = json.loads(response["HX-Trigger"])["n26-toasts"]
+        assert [(t["variant"], t["message"]) for t in toasts] == [
+            ("success", "Rolled 63: Old Ruins added to the campaign, unclaimed.")
+        ]
+
+        response = client.post(
+            reverse("n26-campaign-roll-starting", args=[campaign.pk, slag_kings.pk]),
+            {"type": str(territory.pk), "table": str(journal.pk), "rolled": "4"},
+            HTTP_HX_REQUEST="true",
+        )
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert 'id="n26-campaign-gangs" hx-swap-oob="true"' in body
+        assert "Iron Forge" in body
+        toasts = json.loads(response["HX-Trigger"])["n26-toasts"]
+        assert [t["message"] for t in toasts] == [
+            "Rolled 4: Iron Forge assigned to Slag Kings."
+        ]
+
+    def test_a_refusal_over_htmx_comes_back_in_the_dialog_without_a_toast(
+        self, client, campaign, territory, journal, selection_table, arbitrator
+    ):
+        client.force_login(arbitrator)
+        response = client.post(
+            reverse("n26-campaign-roll-asset", args=[campaign.pk]),
+            {
+                "type": str(territory.pk),
+                "table": str(selection_table.pk),
+                "rolled": "7",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+        assert response.status_code == 200
+        assert "Location" not in response
+        assert "HX-Trigger" not in response
+        assert "HX-Replace-Url" not in response
+        body = response.content.decode()
+        host = body.split('id="n26-roll-dialog-host"')[1]
+        assert host.lstrip().startswith('hx-swap-oob="true"')
+        # The open panel is deleted by id before the host arrives, so htmx
+        # has nothing to settle the new panel's attributes against.
+        assert body.index(
+            '<div id="n26-dialog" hx-swap-oob="delete"></div>'
+        ) < body.index('id="n26-roll-dialog-host"')
+        assert "<dialog" in body and "You cannot roll 7 on a D66." in body
+        # The typed roll is still in the field for the reader to fix.
+        assert 'value="7"' in body
+        assert "n26-campaign-assets" not in body
+        assert not CampaignAsset.objects.filter(campaign=campaign).exists()
+
+        # A table not offered lands the same way, in the form's words.
+        response = client.post(
+            reverse("n26-campaign-roll-asset", args=[campaign.pk]),
+            {"type": str(territory.pk), "table": str(journal.pk)},
+            HTTP_HX_REQUEST="true",
+        )
+        assert response.status_code == 200
+        assert "That table is not available here." in response.content.decode()
+
+    def test_the_cards_show_the_first_table_chosen_and_keep_the_posted_one(
+        self, client, campaign, territory, journal, slag_kings, arbitrator
+    ):
+        """Two tables: the first card is checked when the dialog opens, so
+        a roll posts with a table; after a refusal the card the reader
+        chose stays checked and the range sentence follows it."""
+        client.force_login(arbitrator)
+        address = reverse("n26-campaign", args=[campaign.pk])
+        body = client.get(
+            f"{address}?starting={slag_kings.pk}&type={territory.pk}",
+            HTTP_HX_REQUEST="true",
+        ).content.decode()
+        radios = re.findall(r'<input type="radio"[^>]*>', body)
+        assert len(radios) == 2
+        assert [("checked" in radio) for radio in radios] == [True, False]
+        first = re.search(r'value="([^"]+)"', radios[0]).group(1)
+        assert f"x-data=\"{{ table: '{first}', rolled: '' }}\"" in body
+
+        response = client.post(
+            reverse("n26-campaign-roll-starting", args=[campaign.pk, slag_kings.pk]),
+            {"type": str(territory.pk), "table": str(journal.pk), "rolled": "9"},
+            HTTP_HX_REQUEST="true",
+        )
+        body = response.content.decode()
+        assert "You cannot roll 9 on a D6." in body
+        radios = re.findall(r'<input type="radio"[^>]*>', body)
+        assert [("checked" in radio) for radio in radios].count(True) == 1
+        assert re.search(
+            rf'value="{journal.pk}"[^>]*\s+checked', radios[0]
+        ) or re.search(rf'value="{journal.pk}"[^>]*\s+checked', radios[1])
+        assert f"x-data=\"{{ table: '{journal.pk}', rolled: '9' }}\"" in body
+
+        # A table that is not offered falls back to the first card, and what
+        # was typed is escaped for the script that reads it back.
+        response = client.post(
+            reverse("n26-campaign-roll-starting", args=[campaign.pk, slag_kings.pk]),
+            {"type": str(territory.pk), "table": "nonsense", "rolled": "1'+x"},
+            HTTP_HX_REQUEST="true",
+        )
+        body = response.content.decode()
+        radios = re.findall(r'<input type="radio"[^>]*>', body)
+        assert [("checked" in radio) for radio in radios] == [True, False]
+        assert f"x-data=\"{{ table: '{first}', rolled: '1\\u0027+x' }}\"" in body
 
     def test_the_gang_owner_cannot_roll_or_open_and_a_stranger_finds_nothing(
         self, client, campaign, territory, journal, selection_table, slag_kings, owner
@@ -833,19 +1052,32 @@ class TestThePages:
         address = reverse("n26-campaign-tables", args=[campaign.pk])
         page = client.get(address).content.decode()
         assert "Territory Selection Table" in page
-        assert "Given by Territory campaign" in page
+        assert "Included with Territory campaign. Available to every gang." in page
+        assert "D66 · 18 territories" in page
+        assert "D6 · 6 territories" in page
         assert "Goliath Territories" in page
-        assert "Every gang may roll here" in page
+        assert "Available to every gang</legend>" in page
+        assert "Tables of territories the gangs in this campaign can use." in page
+        assert (
+            "Gangs can roll for a starting territory from any of these. You can "
+            "also roll to add unclaimed territories to the campaign."
+        ) in page
+        assert "Territories already rolled stay in the campaign." in page
+        for banned in ("roll on", "holds", "Entries", "pool", "Given by", "opened"):
+            assert banned not in page, banned
 
         with task_queue.capture():
             response = client.post(address, {"open": [str(journal.pk)]}, follow=True)
         task_queue.deliver_all()
-        assert "Opened Goliath Territories to every gang." in response.content.decode()
+        assert (
+            "Made Goliath Territories available to every gang."
+            in response.content.decode()
+        )
         assert journal in tables_in_play(campaign)
         assert journal in tables_held_by(wild_cats, campaign)
 
         response = client.post(address, {}, follow=True)
-        assert "Closed Goliath Territories." in response.content.decode()
+        assert "Withdrew Goliath Territories." in response.content.decode()
         assert journal not in tables_in_play(campaign)
 
         response = client.post(address, {}, follow=True)
@@ -866,9 +1098,13 @@ class TestThePages:
         )
 
         page = client.get(response["Location"]).content.decode()
-        assert "Rolled on a D3" in page
+        assert "Created the table Dust Falls Turf. Add territories to it next." in page
+        assert "Rolled with a D3" in page
         assert "0 of 3 rolls covered" in page
         assert "Old Ruins" in page
+        assert "No territories yet. Add the territories a roll can land on." in page
+        assert "Add a territory" in page and "Add territory" in page
+        assert "Entries" not in page and "entries" not in page
 
         ruins = _holding_assets(campaign).get(name="Old Ruins")
         client.post(

--- a/n26/tests/sandbox/test_asset_rolls.py
+++ b/n26/tests/sandbox/test_asset_rolls.py
@@ -933,6 +933,23 @@ class TestThePages:
             "Rolled 4: Iron Forge assigned to Slag Kings."
         ]
 
+    def test_a_roll_for_a_type_that_has_gone_sends_the_page_over_htmx(
+        self, client, campaign, arbitrator
+    ):
+        """Over htmx a redirect's body is swallowed by hx-swap="none", so an
+        asset type the dialog named but that no longer resolves answers
+        with HX-Redirect and the browser goes to the page. Without htmx it
+        is the redirect it always was."""
+        client.force_login(arbitrator)
+        address = reverse("n26-campaign-roll-asset", args=[campaign.pk])
+
+        response = client.post(address, {"type": "nonsense"}, HTTP_HX_REQUEST="true")
+        assert response.status_code == 204
+        assert response["HX-Redirect"] == reverse("n26-campaign", args=[campaign.pk])
+
+        response = client.post(address, {"type": "nonsense"})
+        assert response.status_code == 302
+
     def test_a_refusal_over_htmx_comes_back_in_the_dialog_without_a_toast(
         self, client, campaign, territory, journal, selection_table, arbitrator
     ):

--- a/n26/tests/sandbox/test_journal_content.py
+++ b/n26/tests/sandbox/test_journal_content.py
@@ -641,6 +641,24 @@ class TestAJournalTerritoryInPlay:
         assert income_reading(gangs["Goliath"]) == 20
         assert income_reading(gangs["Escher"]) == 20
 
+    def test_a_boon_aimed_at_the_models_keeps_its_whole_sentence(self, campaign):
+        """The short form reads as the holding gang gaining the thing, so a
+        boon scoped to the gang's models is not shortened to a bare name."""
+        from n26.core.render import boon_said
+        from n26.library.authoring import create_rule, targets_every_model
+        from n26.tests.sandbox.actions import adds, modifier
+
+        vats = Asset.objects.get(name="Amneo-vats")
+        catfall = create_rule("Catfall")
+        every = modifier(
+            "Amneo-vats: Catfall", targets_every_model(), adds(catfall), carried_by=vats
+        )
+
+        said = boon_said(every)
+
+        assert "Catfall" in said
+        assert said != "Catfall."
+
     def test_the_campaign_page_prints_each_boon_with_its_scope(self, campaign, gangs):
         for name in ("Amneo-vats", "Slug House"):
             add_asset(campaign, Asset.objects.get(name=name))

--- a/n26/tests/sandbox/test_journal_content.py
+++ b/n26/tests/sandbox/test_journal_content.py
@@ -648,17 +648,17 @@ class TestAJournalTerritoryInPlay:
         (territories,) = render_campaign(campaign, viewer=campaign.owner).assets
         by_name = {entry.name: entry for entry in territories.entries}
 
+        # Each boon in the Income column's register: the gangs it applies
+        # to, then what it does. The rule by its plain name — the row
+        # already says Slug House — and never a word about picking.
         vats = by_name["Amneo-vats"]
         assert vats.income == 15
-        (boon,) = vats.boons
-        assert "gangs that have picked Goliath" in boon
-        assert "10" in boon and INCOME in boon
+        assert vats.boons == ["Goliath gangs: +10 Income."]
 
         slug = by_name["Slug House"]
         assert slug.income == 20
-        (boon,) = slug.boons
-        assert "gangs that have picked Goliath" in boon
-        assert "Goliath Controlled" in boon and "Slug House" in boon
+        assert slug.boons == ["Goliath gangs: Goliath Controlled."]
+        assert INCOME == "Income"
 
 
 # --- The House table and the starting roll ---------------------------------

--- a/n26/tests/sandbox/test_journal_content.py
+++ b/n26/tests/sandbox/test_journal_content.py
@@ -768,7 +768,7 @@ class TestTheHouseTable:
 
         # The act itself refuses too, whoever calls it: the gate is not
         # only the dialog's.
-        with pytest.raises(Refusal, match="cannot roll on Goliath Territories"):
+        with pytest.raises(Refusal, match="cannot roll for a territory from Goliath"):
             roll_asset(campaign, goliath, gang=gangs["Goliath"], rolled=1, actor=player)
         roll = roll_asset(
             campaign, goliath, gang=gangs["Goliath"], rolled=1, actor=staff_arbitrator

--- a/n26/tests/sandbox/test_rolling.py
+++ b/n26/tests/sandbox/test_rolling.py
@@ -207,10 +207,10 @@ class TestARollGoesOnTheRecord:
         assert not Assignment.objects.filter(roll=event).exists()
         assert_reconciled(gang)
 
-    def test_a_roll_made_at_the_table_is_entered_and_says_so(self, gang, krago):
+    def test_a_manual_roll_is_entered_and_says_so(self, gang, krago):
         event = roll_for(krago, "Lasting Injuries", rolled=24)
         assert event.roll == 24
-        assert event.note == "Rolled at the table and entered here."
+        assert event.note == "Manual roll."
 
     def test_a_number_the_die_cannot_make_is_refused_in_words(self, gang, krago):
         with pytest.raises(Refusal, match="You cannot roll 37 on a D66"):
@@ -336,7 +336,7 @@ class TestTheHistoryTellsTheRoll:
         assert [(sub.name, sub.kind) for sub in act.subs] == [
             ("Out Cold", "lasting injury")
         ]
-        assert act.note == "Rolled at the table and entered here."
+        assert act.note == "Manual roll."
         assert not any("gained Out Cold" in said for said in sentences(gang))
 
     def test_a_roll_nothing_followed_stands_alone(self, gang, krago):
@@ -484,8 +484,8 @@ class TestThePickScreen:
         # Enter in the field must reach the Enter act, not Roll: the first
         # submit button in the form decides, so an unseen one comes first.
         assert page.index('value="enter"') < page.index('value="roll"')
-        assert 'min="' not in page.split("Your roll from the table")[0][-600:]
-        assert "The number you rolled at the table" in page
+        assert 'min="' not in page.split("Your own roll")[0][-600:]
+        assert "The roll you made yourself" in page
         assert "or add a result by hand" in page
         assert 'name="rolled"' in page
         # The range is a hint in the field, never a browser constraint —
@@ -538,7 +538,7 @@ class TestThePickScreen:
         page = client.get(f"{address}?roll={event.pk}").content.decode()
         assert "Rolled 24" in page
         assert re.search(r"Landed on <strong[^>]*>Out Cold</strong>\.", page)
-        assert "Rolled at the table and entered here." in page
+        assert "Manual roll." in page
         assert 'aria-label="A die showing 2"' in page
         assert 'aria-label="A die showing 4"' in page
         # One result: the panel carries its Add as the main act, and the

--- a/n26/tests/sandbox/test_the_gang_scope_may_name_a_pick.py
+++ b/n26/tests/sandbox/test_the_gang_scope_may_name_a_pick.py
@@ -499,9 +499,7 @@ class TestAConditionalTerritoryBoon:
         (entry,) = territories.entries
 
         assert entry.income == 20
-        (boon,) = entry.boons
-        assert "gangs that have picked Goliath" in boon
-        assert "10" in boon and INCOME in boon
+        assert entry.boons == [f"Goliath gangs: +10 {INCOME}."]
 
 
 # --- Nothing changes for a scope with no conditions ------------------------
@@ -542,18 +540,18 @@ class TestAConditionLessGangScopeIsUnchanged:
 
 class TestWhatTheAuthoringPagesSay:
     def test_the_scope_says_the_condition(self, goliath, houses):
-        assert str(targets_gang(has_gang_pickable(goliath))) == (
-            "gangs that have picked Goliath"
-        )
+        assert str(targets_gang(has_gang_pickable(goliath))) == "Goliath gangs"
         assert str(targets_gang_alone(has_gang_pickable(goliath))) == (
-            "gangs that have picked Goliath (the gang alone)"
+            "Goliath gangs (the gang alone)"
         )
         assert str(targets_gang(has_gang_pickable(goliath, negate=True))) == (
-            "every gang except those that have picked Goliath"
+            "every gang except Goliath gangs"
         )
         assert str(targets_gang(has_gang_pickable(goliath, houses["Escher"]))) == (
-            "gangs that have picked Escher or Goliath"
+            "Escher or Goliath gangs"
         )
+        # Nobody picks a supertype, so the words never say so.
+        assert "picked" not in str(targets_gang(has_gang_pickable(goliath)))
 
     def test_the_sentence_leads_with_the_condition(self, goliath, default_pack):
         boon = modifier(
@@ -565,8 +563,8 @@ class TestWhatTheAuthoringPagesSay:
         sentence = sentence_for(boon, carriage=None)
 
         assert sentence.text == (
-            "For gangs that have picked Goliath, the gang gains Goliath "
-            "Controlled, printed on the gang page."
+            "For Goliath gangs, the gang gains Goliath Controlled, printed on "
+            "the gang page."
         )
 
     def test_the_plan_names_the_condition(self, owner, goliath_type, journal_boons):
@@ -575,7 +573,7 @@ class TestWhatTheAuthoringPagesSay:
 
         (step,) = [s for s in gang_computed(gang).plan if "(gang)" in str(s.effect)]
 
-        assert "[gangs that have picked Goliath (the gang alone)]" in str(step)
+        assert "[Goliath gangs (the gang alone)]" in str(step)
         assert step.ran_in == 1
 
     def test_the_composer_names_the_modifier_after_its_scope_and_reads_it_back(
@@ -602,9 +600,7 @@ class TestWhatTheAuthoringPagesSay:
 
         assert response.status_code == 302, response.content.decode()[:2000]
         (made,) = Modifier.objects.filter(targets_gang__isnull=False)
-        assert made.name == (
-            "gangs that have picked Goliath (the gang alone): adds Goliath Controlled"
-        )
+        assert made.name == "Goliath gangs (the gang alone): adds Goliath Controlled"
         assert [str(p) for p in made.scope.has_gang_pickable.get().pickables.all()] == [
             "Goliath"
         ]


### PR DESCRIPTION
Stacked on #2508 (slice 4 of the territory-tables stack: #2504 → #2505 → #2506 → #2507 → #2508). Fixes the roll dialogs' behaviour and copy after review. No schema change: `makemigrations --check` is clean.

## What changed

**The two roll dialogs on the campaign page post over htmx.** A roll redraws the figures strip, the gangs table, the Assets section and the log in place, closes the dialog, puts the address back to the plain campaign page and shows the result as a toast — no reload, no jump to the gangs table. A refused roll (a number the die cannot make, a table not offered) comes back inside the dialog with the reason. Without JavaScript the form posts as before and lands on the plain campaign page, no anchor, so the message at the top is seen. Whole sections are swapped rather than a row: a roll adds a new line, and an out-of-band swap cannot insert one.

**The own-roll number box was invisible in dark mode until focused.** The template passed `class="max-w-32"` to `<c-ui.input>`, and cotton put that class on the `<input>` *before* the component's own `class="… border bg-[var(--color-input-bg)] …"`. Two `class` attributes on one element: the browser keeps the first, so the input lost its border and background. The field is now `RollAssetForm.rolled` drawn through `c-ui.field` and `c-ui.input` exactly as the campaign budget field is, with no class override. A test asserts the widget carries the component's classes.

**One table is a fact, not a choice.** A dialog offering one table shows "Table  Territory Selection Table · D66" as a detail-list row and posts the table hidden. Several tables are radio cards (name, die); the cards stay live when a number is typed, because a manual roll still has to be read against one table's rows. The range sentence under the field ("A D66 roll is 11 to 66.") follows the selected card, and the submit reads **Use my roll** once a number is typed — a few lines of Alpine; the server validates regardless, and without a script every range sentence shows, each naming its die.

**Copy**, per the review: "The rolled territory will be assigned to Hammerfall."; the "tables Hammerfall holds" line is gone; "manual roll" everywhere "at the table" was, including the pick-roll flow (`ROLL_ENTERED` is now `"Manual roll."`, and `ROLL_ENTERED_BEFORE` keeps rolls recorded under the old note reading as manual); the Tables page says gangs **roll for** a territory and tables **contain** territories, tables are **available**/**withdrawn** rather than opened/closed, and every count takes the asset type's own word ("D66 · 18 territories", never "entries"); the Create table page drops "for this campaign alone". Notes read `Rolled 34 from the Territory Selection Table: Old Ruins. Manual roll.`; history reads `rolled 34 from the Territory Selection Table: Old Ruins (manual roll)`, and the marker is taken off by name so a gang called "Dr. Skabb's Crew" keeps its whole line.

**Also**: a refusal redraw deletes the still-open `#n26-dialog` by id before the new host arrives, otherwise htmx settles the promoted modal's class back to the in-flow one and the dialog lands at the top left. The Log heading's "N earlier acts not shown" count has a host of its own so it moves with the list. Values echoed into the dialog's Alpine scope are `escapejs`-ed and a posted table that is not offered falls back to the first card.

Not in scope (deferred by the maintainer): renaming "Roll territory" and reordering the campaign page.

## Screenshots

Light and dark, taken in the worktree's dev server. The **before** pair shows the invisible input; everything else is after.

| | light | dark |
| --- | --- | --- |
| before: starting roll, two tables | `before-starting-two-tables-light.png` | `before-starting-two-tables-dark.png` |
| starting roll, two tables | `starting-two-tables-light.png` | `starting-two-tables-dark.png` |
| … after typing a roll (Use my roll) | `starting-two-tables-typed-light.png` | `starting-two-tables-typed-dark.png` |
| … second card selected (range follows) | `starting-two-tables-second-radio-light.png` | `starting-two-tables-second-radio-dark.png` |
| starting roll, one table | `starting-one-table-light.png` | `starting-one-table-dark.png` |
| unclaimed roll (pool), one table | `pool-one-table-light.png` | `pool-one-table-dark.png` |
| unclaimed roll, two tables | `pool-light.png` | `pool-dark.png` |
| refusal inside the dialog | `pool-refused-light.png` | `pool-refused-dark.png` |
| campaign page after a roll, toast | `campaign-after-roll-toast-light.png` | `campaign-after-roll-toast-dark.png` |
| Tables page | `tables-light.png` | `tables-dark.png` |
| Create table page | `new-table-light.png` | `new-table-dark.png` |
| a table's page | `table-light.png` | `table-dark.png` |

The files are on the maintainer's machine under the Claude project directory for this repo (`screenshots/jay-roll-copy/`); GitHub has no API for attaching images from the CLI, so they are not embedded here.

## Copy review notes

The copywriter agent kept every reviewed string and changed two of mine ("Create a new territory for this campaign" tooltip; "The territories available to this campaign."). It flagged, and I left as dictated: "The rules generate three per player" (personification), "Choose Not rolled for a plain list." (the skill's pick/choose split), and that "Name *" on the Create table page keeps its asterisk while "Asset type" does not.

## How to try it

1. Open a Territory campaign you arbitrate at `/n26/campaigns/<id>/` with at least one gang. In dark mode, click **Roll starting territory** under a gang: the number box has a border; type a roll and the button reads **Use my roll**.
2. Type `7` and submit: the dialog stays, with "You cannot roll 7 on a D66." inside it. Clear it and click **Roll**: the dialog closes, a toast says what was rolled, and the gang's Territories cell, the Assets table, the figures and the log update without a reload. The address is the plain campaign URL.
3. **Tables** (beside the Assets heading): the lead, the section intro, "Included with Territory campaign. Available to every gang.", "D66 · 18 territories", the "Available to every gang" ticks. **Create table** and a table's page use the same words.
4. `pytest n26/tests/sandbox/test_asset_rolls.py n26/tests/sandbox/test_rolling.py`

## Test plan

- [x] `pytest n26 -n 4` — 5997 passed, 1 xfailed
- [x] `./scripts/fmt.sh`, `manage check`, `makemigrations --check`
- [x] `scripts/check_microcopy.py` over changed files — no warnings on changed lines
- [x] copywriter and code-reviewer agents run; all four reviewer findings fixed
- [x] Screenshots above, light and dark

## Review

Review round 2026-09-09 (independent code review): nothing at or above the bar — no-JS path, out-of-band sections, one-table case, out-of-range manual roll, double-submit, `HX-Replace-Url`, Alpine wiring and the `<c-ui.input>` call sites all checked clean. Two sub-threshold notes fixed: the Boons column keeps a model-scoped boon's whole sentence instead of shortening it to a bare name, and an htmx roll whose asset type no longer resolves answers `HX-Redirect` instead of a swallowed redirect. Pre-existing, out of scope: `n26/library/templates/authoring/_field.html` passes `class=` to `<c-ui.input type="file">`, the same duplicate-attribute bug this PR fixed on the roll dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTc5N9DniP5LSspvHpDANs

