### PR TITLE
fix: let Codex access local PostgreSQL through its Unix socket

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,22 @@
+# Allow local PostgreSQL without opening outbound network access.
+default_permissions = "gyrinx-local"
+
+[permissions.gyrinx-local]
+extends = ":workspace"
+
+[permissions.gyrinx-local.network]
+enabled = true
+
+[permissions.gyrinx-local.network.unix_sockets]
+"/private/tmp/.s.PGSQL.5432" = "allow"
+
+# The proxy permits the socket above; no outbound hosts are allowed.
+[features.network_proxy]
+enabled = true
+
 [shell_environment_policy]
 inherit = "core"
+
+[shell_environment_policy.set]
+GYRINX_DB_HOST = "/private/tmp"
+PGHOST = "/private/tmp"

--- a/.codex/run.sh
+++ b/.codex/run.sh
@@ -30,7 +30,8 @@ export DB_NAME
 DB_NAME=$(worktree_db_name "$PROJECT_DIR")
 export DJANGO_PORT
 DJANGO_PORT=$(worktree_port "$PROJECT_DIR")
-export DB_HOST=localhost
+export DB_HOST="${GYRINX_DB_HOST:-localhost}"
+export PGHOST="$DB_HOST"
 export DB_PORT=5432
 export DB_CONFIG
 DB_CONFIG=$(db_config_for_local)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   commands through `.codex/run.sh` (for example, `.codex/run.sh pytest` or
   `.codex/run.sh manage check`). The existing `scripts/dev.sh` and `scripts/fmt.sh` activate the
   worktree environment themselves.
+- **Codex local database access:** `.codex/config.toml` grants the local PostgreSQL
+  Unix socket (`/private/tmp/.s.PGSQL.5432`) and sets `GYRINX_DB_HOST` / `PGHOST`.
+  `.codex/run.sh` and `scripts/dev.sh` apply this after venv activation. The main
+  checkout uses `gyrinx_main`; child worktrees fork its curated content as usual.
+  Start a new Codex task after changing permission configuration. For a running
+  task with the old sandbox, request approved access for database commands when
+  they fail with `Operation not permitted`; do not replace PostgreSQL with SQLite
+  or skip real-data checks. Pytest still uses its separate test database; use the
+  worktree database for smoke tests against the copied content.
 
 **Key Principles:**
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -147,6 +147,11 @@ else
   exit 1
 fi
 
+# Older venv activation hooks overwrite DB_HOST. Apply the selected transport
+# after activation so Django and the PostgreSQL CLI use the same connection.
+export DB_HOST="${GYRINX_DB_HOST:-localhost}"
+export PGHOST="$DB_HOST"
+
 # Ensure .env exists — copy from main worktree if missing
 if [ ! -f "${WT_ROOT}/.env" ] && [ "$WT_ROOT" != "$MAIN_WT" ] && [ -f "${MAIN_WT}/.env" ]; then
   echo "Copying .env from main worktree..."
@@ -182,7 +187,7 @@ if [ "$RESET_DB" = true ]; then
     echo "ERROR: Cannot reset the main worktree database (it's the template)."
     exit 1
   fi
-  if psql -lqt | cut -d \| -f 1 | grep -qw "$DB_NAME"; then
+  if psql -lqt | cut -d \| -f 1 | grep -w "$DB_NAME" >/dev/null; then
     echo "Dropping database '$DB_NAME'..."
     dropdb "$DB_NAME"
   fi
@@ -192,7 +197,9 @@ fi
 # Ensure database exists
 # ---------------------------------------------------------------------------
 db_exists() {
-  psql -lqt | cut -d \| -f 1 | grep -qw "$1"
+  # Consume the full list: grep -q can SIGPIPE cut under pipefail when many
+  # worktree databases exist, incorrectly reporting a present database missing.
+  psql -lqt | cut -d \| -f 1 | grep -w "$1" >/dev/null
 }
 
 if ! db_exists "$DB_NAME"; then


### PR DESCRIPTION
## Summary

- Let Codex connect to the local PostgreSQL Unix socket so Django commands can read `gyrinx_main` and worktrees can test against its copied content. The project permission profile retains workspace filesystem restrictions and uses the network proxy with no outbound host allowlist.
- Apply `GYRINX_DB_HOST` after virtualenv activation in `.codex/run.sh` and `scripts/dev.sh`, and keep PostgreSQL CLI tools on the same connection with `PGHOST`.
- Fix `scripts/dev.sh` incorrectly reporting an existing database as missing when `grep -q` closes a long database-list pipeline early under `pipefail`.

## Test plan

- [x] Run `./scripts/fmt.sh` and all pre-commit hooks.
- [x] Verify real content reads, a populated worktree copy, and a temporary write/rollback inside the configured Codex sandbox.
- [x] Confirm direct TCP connections and an unlisted internet request remain blocked.
- [x] Run the full suite with `pytest -n 4`: 10,386 passed, 12 skipped, 1 expected failure.

New Codex tasks load the project permission profile. Existing tasks retain their prior sandbox settings.
