### PR TITLE
feat: add Codex worktree setup, cleanup and dev URL scripts

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,88 @@
+# Codex local worktrees
+
+Use these scripts in the ChatGPT/Codex local environment settings. Codex creates
+and removes the Git worktree; the scripts prepare and remove its local database.
+They use the project's existing macOS/Homebrew development environment: Git,
+Bash, uv, Node/npm, PostgreSQL 16 and a populated `gyrinx_main` template. Run
+`./scripts/setup-local-postgres.sh` once from the main checkout first.
+
+## Setup
+
+Set the setup command to:
+
+```bash
+bash .codex/setup.sh
+```
+
+`CODEX_WORKTREE_PATH` selects the new worktree, even when the command runs from
+the source workspace. `CODEX_SOURCE_TREE_PATH` selects the workspace whose `.env`
+is copied if the new worktree has none. Both paths must be roots of worktrees in
+the same repository. Without these variables, setup uses the current checkout
+and copies `.env` from the main checkout.
+
+Setup preserves an existing `.env`, creates separate Python and npm dependencies,
+forks a database from `gyrinx_main`, runs migrations and builds both editions' CSS.
+It exits without starting a server and can be rerun after a partial failure.
+Shared `.env`, `.venv` and `node_modules` symlinks are rejected. Database cloning
+uses the existing dev script, which briefly disconnects template DB connections.
+
+Setup exports do not persist into later agent commands. Use `.codex/run.sh`
+for Python commands, such as `.codex/run.sh manage check`.
+
+## Cleanup
+
+Run this command **before** the worktree is removed, with
+`CODEX_WORKTREE_PATH` set to its absolute path:
+
+```bash
+bash .codex/cleanup.sh
+```
+
+With no path variable, cleanup targets the current checkout. It drops only that
+worktree's database and its pytest databases (`test_<db>` and `test_<db>_gwN`).
+It refuses the main checkout, another repository, missing paths and subdirectories.
+It connects explicitly to local PostgreSQL on port 5432 as the current OS user,
+using `GYRINX_DB_HOST` (the `/private/tmp` socket configured in `.codex/config.toml`)
+or localhost when unset. Remote hosts are rejected.
+Stop the worktree's dev server and test runs first: cleanup fails if a database is
+still in use. It can be rerun if databases are already gone.
+
+Preview the selection with `bash .codex/cleanup.sh --dry-run`.
+
+Configure this as a cleanup command if your app exposes a hook that runs before
+worktree deletion. Otherwise run it manually before deleting the worktree.
+The published local environment docs describe setup and actions, but do not
+specify a cleanup hook's timing or variables. Codex handles deleting the checkout,
+including dependencies and logs; this script does not remove files or branches.
+For worktrees already deleted, use `./scripts/cleanup-worktree-dbs.sh` to preview
+orphaned databases and its `--force` option to remove them.
+
+## Suggested toolbar actions
+
+Add these commands as local environment actions. They run from the selected
+checkout in the integrated terminal.
+
+| Action | Command |
+| --- | --- |
+| Run dev server | `./scripts/dev.sh` |
+| Open dev server | `./.codex/dev-url.sh --open` |
+| Show dev URL | `./.codex/dev-url.sh` |
+| Check Django | `./.codex/run.sh manage check` |
+| Run core tests | `./.codex/run.sh pytest -m core -n 4` |
+| Format | `./scripts/fmt.sh` |
+
+The URL helper calculates the checkout's port without requiring setup or a running
+server. Opening it does not start the server. Stop the Run action with Ctrl-C in
+its terminal. Keep database cleanup out of the everyday toolbar.
+
+## Check the scripts
+
+```bash
+python3 -m unittest discover -s .codex/tests -p 'test_lifecycle.py'
+```
+
+These tests use temporary Git repositories and stub development/Postgres commands;
+they do not install dependencies or access the machine's databases.
+
+References: [Worktrees](https://learn.chatgpt.com/docs/environments/git-worktrees)
+and [Local environments](https://learn.chatgpt.com/docs/environments/local-environment).

--- a/.codex/cleanup.sh
+++ b/.codex/cleanup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run before Codex removes the worktree. Codex owns file/branch deletion.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=worktree.sh
+source "$SCRIPT_DIR/worktree.sh"
+
+DRY_RUN=false
+case "${1:-}" in
+  --dry-run) DRY_RUN=true; shift ;;
+  "") ;;
+  *) codex_error "Usage: .codex/cleanup.sh [--dry-run]" ;;
+esac
+[ "$#" -eq 0 ] || codex_error "Usage: .codex/cleanup.sh [--dry-run]"
+PROJECT_DIR=$(codex_tree_root "${CODEX_WORKTREE_PATH:-$(git rev-parse --show-toplevel)}")
+cd "$PROJECT_DIR"
+source "$PROJECT_DIR/scripts/lib/worktree.sh"
+
+DB_NAME=$(worktree_db_name "$PROJECT_DIR")
+[[ "$DB_NAME" =~ ^gyrinx_wt_[0-9a-f]{8}$ ]] || codex_error "Cannot clean up the main worktree database."
+PG_BIN_DIR=$(homebrew_postgres_bin)
+if [ -n "$PG_BIN_DIR" ]; then
+  export PATH="$PG_BIN_DIR:$PATH"
+fi
+
+# Use the local cluster, regardless of inherited production/test DB variables.
+# Explicit arguments also override a PG service's connection defaults.
+DB_HOST="${GYRINX_DB_HOST:-localhost}"
+case "$DB_HOST" in
+  localhost|127.0.0.1|/tmp|/private/tmp) ;;
+  *) codex_error "Cleanup requires a local PostgreSQL host or socket directory." ;;
+esac
+PG_ARGS=(--host="$DB_HOST" --port=5432 --username="$(whoami)" --no-password)
+DB_PATTERN="^(${DB_NAME}|test_${DB_NAME}(_gw[0-9]+)?)$"
+# Capture first: a failed query must fail cleanup, not look like an empty list.
+DATABASES=$(psql "${PG_ARGS[@]}" --dbname=postgres -X -v ON_ERROR_STOP=1 -Atc \
+  "SELECT datname FROM pg_database WHERE datname ~ '$DB_PATTERN' ORDER BY datname;")
+
+if [ -z "$DATABASES" ]; then
+  echo "No databases to remove for $PROJECT_DIR."
+  exit 0
+fi
+
+while IFS= read -r db; do
+  [[ "$db" =~ $DB_PATTERN ]] || codex_error "Unexpected database name: $db"
+  if [ "$DRY_RUN" = true ]; then
+    echo "Would drop database: $db"
+  else
+    echo "Dropping database: $db"
+    # No --force: fail if a dev server or test run still has connections.
+    if ! dropdb "${PG_ARGS[@]}" --maintenance-db=postgres --if-exists "$db"; then
+      codex_error "Could not drop $db. Stop this worktree's dev server and tests, then retry."
+    fi
+  fi
+done <<< "$DATABASES"

--- a/.codex/cleanup.sh
+++ b/.codex/cleanup.sh
@@ -26,7 +26,8 @@ if [ -n "$PG_BIN_DIR" ]; then
 fi
 
 # Use the local cluster, regardless of inherited production/test DB variables.
-# Explicit arguments also override a PG service's connection defaults.
+# libpq's hostaddr overrides --host, even when it names a Unix socket.
+unset PGHOSTADDR PGSERVICE PGSERVICEFILE
 DB_HOST="${GYRINX_DB_HOST:-localhost}"
 case "$DB_HOST" in
   localhost|127.0.0.1|/tmp|/private/tmp) ;;

--- a/.codex/dev-url.sh
+++ b/.codex/dev-url.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Print or open the dev URL for the checkout running this toolbar action.
+
+set -euo pipefail
+
+case "${1:-}" in
+  ""|--open) ;;
+  *) echo "Usage: .codex/dev-url.sh [--open]" >&2; exit 2 ;;
+esac
+[ "$#" -le 1 ] || { echo "Usage: .codex/dev-url.sh [--open]" >&2; exit 2; }
+PROJECT_DIR=$(git rev-parse --show-toplevel)
+source "$PROJECT_DIR/scripts/lib/worktree.sh"
+URL="http://localhost:$(worktree_port "$PROJECT_DIR")/"
+printf '%s\n' "$URL"
+
+if [ "${1:-}" = --open ]; then
+  case "$(uname -s)" in
+    Darwin) exec open "$URL" ;;
+    Linux) exec xdg-open "$URL" ;;
+    *) echo "Open the URL above in your browser." >&2; exit 1 ;;
+  esac
+fi

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -2,10 +2,34 @@
 
 set -euo pipefail
 
-PROJECT_DIR=$(git rev-parse --show-toplevel)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=worktree.sh
+source "$SCRIPT_DIR/worktree.sh"
+
+[ "$#" -eq 0 ] || codex_error "Usage: .codex/setup.sh"
+PROJECT_DIR=$(codex_tree_root "${CODEX_WORKTREE_PATH:-$(git rev-parse --show-toplevel)}")
 cd "$PROJECT_DIR"
 
-# Reuse the normal development bootstrap. In setup-only mode it provisions the
-# worktree venv and frontend dependencies, forks the per-worktree database,
-# migrates it, and builds CSS without leaving a server running.
+# A new worktree can be based on another child worktree, not just main.
+# Keep any existing local configuration when setup is rerun.
+if [ -n "${CODEX_SOURCE_TREE_PATH:-}" ]; then
+  SOURCE_DIR=$(codex_tree_root "$CODEX_SOURCE_TREE_PATH")
+else
+  source "$PROJECT_DIR/scripts/lib/worktree.sh"
+  SOURCE_DIR=$(_main_worktree)
+fi
+
+# These directories must belong to this worktree: dependency installers can
+# otherwise mutate a source checkout through a symlink.
+for path in .env .venv node_modules; do
+  [ ! -L "$PROJECT_DIR/$path" ] || codex_error "Remove the shared symlink before setup: $PROJECT_DIR/$path"
+done
+if [ ! -e "$PROJECT_DIR/.env" ] && [ -f "$SOURCE_DIR/.env" ]; then
+  (umask 077; cp "$SOURCE_DIR/.env" "$PROJECT_DIR/.env")
+  chmod 600 "$PROJECT_DIR/.env"
+  echo "Copied .env from source workspace."
+fi
+
+# Provisions dependencies, forks the worktree database, migrates and builds CSS.
+# No background server is left running by the setup hook.
 exec ./scripts/dev.sh --no-watch --setup-only

--- a/.codex/tests/test_lifecycle.py
+++ b/.codex/tests/test_lifecycle.py
@@ -1,0 +1,248 @@
+"""Exercise the real shell entry points without touching local databases."""
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class CodexLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="codex lifecycle ")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.source = self.root / "source tree"
+        self.target = self.root / "new tree"
+        self.bin = self.root / "tools" / "bin"
+        self.bin.mkdir(parents=True)
+        self.log = self.root / "commands.log"
+        self.env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("CODEX_", "GIT_", "PG", "GYRINX_"))
+        }
+        self.env.update(
+            PATH=f"{self.bin}:{os.environ['PATH']}",
+            COMMAND_LOG=str(self.log),
+            FAKE_TOOLS=str(self.bin.parent),
+        )
+        self.source.mkdir()
+        self.git("init", "-q", cwd=self.source)
+        (self.source / ".codex").mkdir()
+        (self.source / "scripts" / "lib").mkdir(parents=True)
+        for name in ("setup.sh", "cleanup.sh", "worktree.sh", "dev-url.sh"):
+            shutil.copy2(REPO / ".codex" / name, self.source / ".codex" / name)
+        shutil.copy2(
+            REPO / "scripts" / "lib" / "worktree.sh",
+            self.source / "scripts" / "lib" / "worktree.sh",
+        )
+        self.write_script(
+            self.source / "scripts" / "dev.sh",
+            'printf "dev|%s|%s\\n" "$PWD" "$*" >> "$COMMAND_LOG"\n'
+            'exit "${DEV_STATUS:-0}"\n',
+        )
+        self.git("add", ".", cwd=self.source)
+        self.git(
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@localhost",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-qm",
+            "Fixture",
+            cwd=self.source,
+        )
+        self.git("worktree", "add", "-q", "--detach", str(self.target), cwd=self.source)
+        self.env.update(
+            CODEX_SOURCE_TREE_PATH=str(self.source),
+            CODEX_WORKTREE_PATH=str(self.target),
+        )
+        self.db = (
+            "gyrinx_wt_"
+            + hashlib.md5(str(self.target).encode(), usedforsecurity=False).hexdigest()[
+                :8
+            ]
+        )
+        self.write_script(self.bin / "brew", 'echo "$FAKE_TOOLS"\n')
+        self.write_script(
+            self.bin / "psql",
+            'printf "psql|%s\\n" "$*" >> "$COMMAND_LOG"\n'
+            'printf "%s\\n" "${DATABASES:-}"\nexit "${QUERY_STATUS:-0}"\n',
+        )
+        self.write_script(
+            self.bin / "dropdb",
+            'printf "dropdb|%s\\n" "$*" >> "$COMMAND_LOG"\nexit "${DROP_STATUS:-0}"\n',
+        )
+        self.write_script(self.bin / "uname", "echo Darwin\n")
+        self.write_script(
+            self.bin / "open", 'printf "open|%s\\n" "$*" >> "$COMMAND_LOG"\n'
+        )
+
+    def write_script(self, path, body):
+        path.write_text("#!/bin/bash\nset -eu\n" + body)
+        path.chmod(0o755)
+
+    def git(self, *args, cwd):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+
+    def run_script(self, script, *args, cwd=None, **env):
+        return subprocess.run(
+            ["/bin/bash", str(self.source / ".codex" / script), *args],
+            cwd=cwd or self.source,
+            env=self.env | env,
+            text=True,
+            capture_output=True,
+        )
+
+    def commands(self):
+        return self.log.read_text() if self.log.exists() else ""
+
+    def test_setup_uses_target_from_unrelated_cwd_and_copies_source_env(self):
+        (self.source / ".env").write_text("LOCAL_SETTING=source\n")
+        result = self.run_script("setup.sh", cwd=self.root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.target / ".env").read_text(), "LOCAL_SETTING=source\n")
+        self.assertEqual((self.target / ".env").stat().st_mode & 0o777, 0o600)
+        self.assertIn(f"dev|{self.target}|--no-watch --setup-only", self.commands())
+        self.assertNotIn("LOCAL_SETTING", result.stdout)
+
+    def test_setup_preserves_existing_env_and_propagates_failure(self):
+        (self.source / ".env").write_text("source\n")
+        (self.target / ".env").write_text("target\n")
+        result = self.run_script("setup.sh", DEV_STATUS="7")
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual((self.target / ".env").read_text(), "target\n")
+
+    def test_setup_uses_explicit_child_source(self):
+        child = self.root / "another source"
+        self.git("worktree", "add", "-q", "--detach", str(child), cwd=self.source)
+        (self.source / ".env").write_text("main\n")
+        (child / ".env").write_text("child\n")
+        result = self.run_script("setup.sh", CODEX_SOURCE_TREE_PATH=str(child))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.target / ".env").read_text(), "child\n")
+
+    def test_setup_rejects_shared_symlinks(self):
+        for name in (".env", ".venv", "node_modules"):
+            with self.subTest(name=name):
+                link = self.target / name
+                link.symlink_to(self.root / "missing")
+                result = self.run_script("setup.sh")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn("dev|", self.commands())
+                link.unlink()
+
+    def test_setup_falls_back_to_current_checkout(self):
+        (self.source / ".env").write_text("main\n")
+        result = self.run_script(
+            "setup.sh",
+            cwd=self.target,
+            CODEX_SOURCE_TREE_PATH="",
+            CODEX_WORKTREE_PATH="",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.target / ".env").read_text(), "main\n")
+
+    def test_invalid_paths_fail_before_any_command(self):
+        other = self.root / "unrelated repo"
+        other.mkdir()
+        self.git("init", "-q", cwd=other)
+        for path in (self.root / "missing", self.target / "scripts", other):
+            for script in ("setup.sh", "cleanup.sh"):
+                with self.subTest(path=path, script=script):
+                    result = self.run_script(script, CODEX_WORKTREE_PATH=str(path))
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertEqual(self.commands(), "")
+        result = self.run_script("setup.sh", CODEX_SOURCE_TREE_PATH=str(other))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.commands(), "")
+
+    def test_cleanup_refuses_main_even_via_symlink(self):
+        alias = self.root / "main alias"
+        alias.symlink_to(self.source, target_is_directory=True)
+        for path in (self.source, alias):
+            result = self.run_script("cleanup.sh", CODEX_WORKTREE_PATH=str(path))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("main worktree", result.stderr)
+            self.assertEqual(self.commands(), "")
+
+    def test_cleanup_selects_exact_database_family_and_pins_socket(self):
+        family = [
+            self.db,
+            f"test_{self.db}",
+            f"test_{self.db}_gw0",
+            f"test_{self.db}_gw12",
+        ]
+        result = self.run_script(
+            "cleanup.sh",
+            DATABASES="\n".join(family),
+            GYRINX_DB_HOST="/private/tmp",
+            PGHOST="remote.invalid",
+            PGPORT="9999",
+            CODEX_WORKTREE_PATH=f"{self.target}/",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.commands().splitlines()
+        self.assertIn(f"^({self.db}|test_{self.db}(_gw[0-9]+)?)$", commands[0])
+        self.assertEqual(len(commands), 5)
+        for line, database in zip(commands[1:], family, strict=True):
+            self.assertTrue(line.endswith(f" {database}"), line)
+            self.assertIn("--host=/private/tmp --port=5432", line)
+            self.assertNotIn("--force", line)
+            self.assertNotIn("remote.invalid", line)
+
+    def test_cleanup_dry_run_and_empty_database_list(self):
+        result = self.run_script("cleanup.sh", "--dry-run", DATABASES=self.db)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"Would drop database: {self.db}", result.stdout)
+        self.assertNotIn("dropdb|", self.commands())
+        result = self.run_script("cleanup.sh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No databases to remove", result.stdout)
+        self.assertNotIn("dropdb|", self.commands())
+
+    def test_cleanup_propagates_query_and_drop_failures(self):
+        result = self.run_script("cleanup.sh", QUERY_STATUS="9")
+        self.assertEqual(result.returncode, 9)
+        self.assertNotIn("dropdb|", self.commands())
+        result = self.run_script("cleanup.sh", DATABASES=self.db, DROP_STATUS="1")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Stop this worktree's dev server", result.stderr)
+
+    def test_cleanup_refuses_unexpected_names_and_remote_host(self):
+        for database in ("gyrinx_main", "gyrinx_wt_deadbeef", f"test_{self.db}_other"):
+            result = self.run_script("cleanup.sh", DATABASES=database)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn("dropdb|", self.commands())
+        result = self.run_script("cleanup.sh", GYRINX_DB_HOST="remote.invalid")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("dropdb|", self.commands())
+
+    def test_url_uses_current_worktree_ignoring_inherited_port_and_hook_path(self):
+        result = self.run_script(
+            "dev-url.sh", "--open", cwd=self.target, DJANGO_PORT="1"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        url = result.stdout.strip()
+        self.assertRegex(url, r"^http://localhost:[89][0-9]{3}/$")
+        self.assertIn(f"open|{url}", self.commands())
+        result = self.run_script("dev-url.sh", cwd=self.source)
+        self.assertEqual(result.stdout.strip(), "http://localhost:8000/")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.codex/tests/test_lifecycle.py
+++ b/.codex/tests/test_lifecycle.py
@@ -71,14 +71,20 @@ class CodexLifecycleTests(unittest.TestCase):
             ]
         )
         self.write_script(self.bin / "brew", 'echo "$FAKE_TOOLS"\n')
+        reject_remote_settings = (
+            'if [ -n "${PGHOSTADDR:-}${PGSERVICE:-}${PGSERVICEFILE:-}" ]; then\n'
+            '  echo "Inherited connection override" >&2; exit 42\n'
+            "fi\n"
+        )
         self.write_script(
             self.bin / "psql",
-            'printf "psql|%s\\n" "$*" >> "$COMMAND_LOG"\n'
+            reject_remote_settings + 'printf "psql|%s\\n" "$*" >> "$COMMAND_LOG"\n'
             'printf "%s\\n" "${DATABASES:-}"\nexit "${QUERY_STATUS:-0}"\n',
         )
         self.write_script(
             self.bin / "dropdb",
-            'printf "dropdb|%s\\n" "$*" >> "$COMMAND_LOG"\nexit "${DROP_STATUS:-0}"\n',
+            reject_remote_settings
+            + 'printf "dropdb|%s\\n" "$*" >> "$COMMAND_LOG"\nexit "${DROP_STATUS:-0}"\n',
         )
         self.write_script(self.bin / "uname", "echo Darwin\n")
         self.write_script(
@@ -204,6 +210,20 @@ class CodexLifecycleTests(unittest.TestCase):
             self.assertIn("--host=/private/tmp --port=5432", line)
             self.assertNotIn("--force", line)
             self.assertNotIn("remote.invalid", line)
+
+    def test_cleanup_clears_inherited_address_and_service(self):
+        for host in ("localhost", "/private/tmp"):
+            with self.subTest(host=host):
+                result = self.run_script(
+                    "cleanup.sh",
+                    DATABASES=self.db,
+                    GYRINX_DB_HOST=host,
+                    PGHOSTADDR="192.0.2.1",
+                    PGSERVICE="remote",
+                    PGSERVICEFILE="/unused/remote-service.conf",
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.commands().count("dropdb|"), 2)
 
     def test_cleanup_dry_run_and_empty_database_list(self):
         result = self.run_script("cleanup.sh", "--dry-run", DATABASES=self.db)

--- a/.codex/worktree.sh
+++ b/.codex/worktree.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared path validation for the Codex lifecycle scripts.
+
+CODEX_SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+codex_error() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Require an existing repository root in the same Git repository as this script.
+# Canonicalise paths so trailing slashes and symlinks use the normal DB hash.
+codex_tree_root() {
+  local path="$1" root common script_common
+  root=$(cd "$path" && pwd -P) || return 1
+  [ "$root" = "$(git -C "$root" rev-parse --show-toplevel)" ] || {
+    echo "ERROR: Expected a Git worktree root: $path" >&2
+    return 1
+  }
+  common=$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)
+  script_common=$(git -C "$CODEX_SCRIPT_ROOT" rev-parse --path-format=absolute --git-common-dir)
+  [ "$common" = "$script_common" ] || {
+    echo "ERROR: Worktree belongs to another repository: $path" >&2
+    return 1
+  }
+  printf '%s\n' "$root"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - The session hook also sets `DB_NAME` and `DJANGO_PORT` per-worktree — `manage` and `pytest`
   automatically target the correct database.
 - **Codex local worktrees:** configure `.codex/setup.sh` as the local-environment setup script.
+  Setup honours `CODEX_SOURCE_TREE_PATH` and `CODEX_WORKTREE_PATH`. Run `.codex/cleanup.sh`
+  before deleting a worktree to remove its database; see [.codex/README.md](.codex/README.md)
+  for lifecycle commands and suggested toolbar actions.
   Codex shell commands do not inherit Claude's `CLAUDE_ENV_FILE`, so run direct Python/Django
   commands through `.codex/run.sh` (for example, `.codex/run.sh pytest` or
   `.codex/run.sh manage check`). The existing `scripts/dev.sh` and `scripts/fmt.sh` activate the


### PR DESCRIPTION
## Summary

- Make `.codex/setup.sh` use `CODEX_WORKTREE_PATH` and copy a missing `.env` from `CODEX_SOURCE_TREE_PATH`, then provision the selected worktree through the existing dev script.
- Add `.codex/cleanup.sh` to remove only that worktree's database and pytest databases before deletion. It supports a dry run, honours the local PostgreSQL socket configuration, and refuses the main checkout or remote hosts.
- Add `.codex/dev-url.sh` to print or open the worktree's dev URL, plus setup, cleanup and toolbar instructions in `.codex/README.md`.

## Test plan

- [x] Thirteen isolated lifecycle regression tests, including invalid paths, existing configuration, database selection, failure handling and inherited PostgreSQL address/service overrides.
- [x] Real setup: dependencies, database clone, migrations and both CSS builds; Django system checks passed.
- [x] Real cleanup: dry run preserved all databases; cleanup removed only the selected family and preserved a similarly named database; repeated cleanup succeeded.
- [x] Local cleanup dry run with remote `PGHOSTADDR` and service overrides injected; connection stayed local.
- [x] Repository formatting and shell syntax checks.
- [x] Full suite: `pytest -n 4` — 10,409 passed, 12 skipped, 1 expected failure.
