### PR TITLE
feat: allow multiple migration leaves per app; add migration-watch workflow

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -59,7 +59,9 @@ jobs:
           bandit -c pyproject.toml -r . --baseline bandit/bandit-baseline.json
 
       - name: Check for migration conflicts
+        # The check tells a branch's own leaves from main's, so it needs main.
         run: |
+          git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
           source .venv/bin/activate && \
           ./scripts/check_migration_conflicts.sh
 

--- a/.github/workflows/migration-watch.yml
+++ b/.github/workflows/migration-watch.yml
@@ -55,16 +55,22 @@ jobs:
             prs=$(gh pr view "$ASKED_PR" --repo "$GITHUB_REPOSITORY" --json number,headRefOid \
               | jq -c '[{number: .number, sha: .headRefOid}]')
           else
-            prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
-              --json number,headRefOid,files,isDraft \
-              | jq -c '[.[] | select(any(.files[]; .path | test("/migrations/[^/]+\\.py$"))) | {number: .number, sha: .headRefOid}]')
+            # One diff listing per open pull request: `--json files` stops at
+            # a hundred files and would hide a migration in a large change.
+            prs="[]"
+            for pr in $(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 --json number --jq '.[].number'); do
+              if gh pr diff "$pr" --repo "$GITHUB_REPOSITORY" --name-only | grep -Eq '/migrations/[^/]+\.py$'; then
+                sha=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
+                prs=$(jq -cn --argjson list "$prs" --argjson n "$pr" --arg sha "$sha" '$list + [{number: $n, sha: $sha}]')
+              fi
+            done
           fi
           echo "prs=$prs" >> "$GITHUB_OUTPUT"
           echo "checking: $prs"
 
   check:
     needs: plan
-    if: needs.plan.outputs.prs != '[]'
+    if: needs.plan.outputs.prs != '' && needs.plan.outputs.prs != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -95,19 +101,29 @@ jobs:
       PR_SHA: ${{ matrix.pr.sha }}
       REPORT_DIR: ${{ github.workspace }}/.migration-watch
     steps:
+      # No token left in .git/config: the branch's own code runs in this job,
+      # and the repository is public, so fetching needs no credentials.
       - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Merge the pull request into main in a throwaway tree
-        id: merge
+      - name: Fetch the pull request
+        id: fetch
         continue-on-error: true
         run: |
           mkdir -p "$REPORT_DIR"
+          git fetch --no-tags origin "pull/$PR_NUMBER/head:refs/remotes/pr/$PR_NUMBER" 2>&1 | tee "$REPORT_DIR/fetch.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      - name: Merge the pull request into main in a throwaway tree
+        id: merge
+        if: steps.fetch.outcome == 'success'
+        continue-on-error: true
+        run: |
           git config user.name "migration-watch"
           git config user.email "migration-watch@users.noreply.github.com"
-          git fetch --no-tags origin "pull/$PR_NUMBER/head:refs/remotes/pr/$PR_NUMBER"
           git checkout -q -b merged origin/main
           git merge --no-edit --no-ff "refs/remotes/pr/$PR_NUMBER" 2>&1 | tee "$REPORT_DIR/merge.log"
           test "${PIPESTATUS[0]}" -eq 0
@@ -170,6 +186,7 @@ jobs:
         continue-on-error: true
         run: |
           source .venv/bin/activate
+          git checkout -q merged
           manage check_migration_conflicts --base origin/main 2>&1 | tee "$REPORT_DIR/leaves.log"
           test "${PIPESTATUS[0]}" -eq 0
 
@@ -179,6 +196,7 @@ jobs:
         continue-on-error: true
         run: |
           source .venv/bin/activate
+          git checkout -q merged
           manage check_migration_overlap --base origin/main --head "refs/remotes/pr/$PR_NUMBER" \
             --json "$REPORT_DIR/overlap.json" 2>&1 | tee "$REPORT_DIR/overlap.log"
           test "${PIPESTATUS[0]}" -eq 0
@@ -186,9 +204,10 @@ jobs:
       # A pull request from a fork runs with a read-only token, so its own
       # run cannot report; the fan-out from main covers it with a write token.
       - name: Report on the pull request
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ github.token }}
+          FETCH: ${{ steps.fetch.outcome }}
           MERGE: ${{ steps.merge.outcome }}
           REPLAY_MAIN: ${{ steps.replay_main.outcome }}
           REPLAY: ${{ steps.replay.outcome }}

--- a/.github/workflows/migration-watch.yml
+++ b/.github/workflows/migration-watch.yml
@@ -26,8 +26,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 # A newer push to main supersedes an older run over the same open pull
 # requests; a pull request's own runs supersede each other.
@@ -38,6 +36,9 @@ concurrency:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       prs: ${{ steps.list.outputs.prs }}
     steps:
@@ -72,6 +73,10 @@ jobs:
     needs: plan
     if: needs.plan.outputs.prs != '' && needs.plan.outputs.prs != '[]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -215,5 +220,8 @@ jobs:
           LEAVES: ${{ steps.leaves.outcome }}
           OVERLAP: ${{ steps.overlap.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # Branch code ran in the steps above and could have rewritten the
+        # script on disk; take main's copy again right before running it.
         run: |
+          git checkout origin/main -- scripts
           python3 scripts/migration_watch_report.py

--- a/.github/workflows/migration-watch.yml
+++ b/.github/workflows/migration-watch.yml
@@ -1,0 +1,200 @@
+name: Migration watch
+
+# Re-checks every open pull request that adds a migration whenever main gains
+# one, and checks a pull request against the current main when it changes.
+# Each check merges the branch into main in a throwaway tree and asks the
+# questions the next deploy will: does migrating main and then the merge
+# succeed, do the models still agree with the migrations, does the branch add
+# one leaf per app, and does a branch migration touch what main changed since
+# the branch forked. The answers land in one comment on the pull request and
+# a non-required status on its head commit. Nothing here blocks a merge; it
+# tells the author early instead of at deploy time.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/migrations/**"
+  pull_request:
+    paths:
+      - "**/migrations/**"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to check (blank for every open one)
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+# A newer push to main supersedes an older run over the same open pull
+# requests; a pull request's own runs supersede each other.
+concurrency:
+  group: migration-watch-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'main' }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      prs: ${{ steps.list.outputs.prs }}
+    steps:
+      - id: list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          THIS_PR: ${{ github.event.pull_request.number }}
+          THIS_SHA: ${{ github.event.pull_request.head.sha }}
+          ASKED_PR: ${{ inputs.pr }}
+        run: |
+          if [ "$EVENT" = "pull_request" ]; then
+            prs=$(jq -cn --argjson n "$THIS_PR" --arg sha "$THIS_SHA" '[{number: $n, sha: $sha}]')
+          elif [ -n "$ASKED_PR" ]; then
+            prs=$(gh pr view "$ASKED_PR" --repo "$GITHUB_REPOSITORY" --json number,headRefOid \
+              | jq -c '[{number: .number, sha: .headRefOid}]')
+          else
+            prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+              --json number,headRefOid,files,isDraft \
+              | jq -c '[.[] | select(any(.files[]; .path | test("/migrations/[^/]+\\.py$"))) | {number: .number, sha: .headRefOid}]')
+          fi
+          echo "prs=$prs" >> "$GITHUB_OUTPUT"
+          echo "checking: $prs"
+
+  check:
+    needs: plan
+    if: needs.plan.outputs.prs != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        pr: ${{ fromJson(needs.plan.outputs.prs) }}
+    name: "PR #${{ matrix.pr.number }}"
+    services:
+      postgres:
+        image: postgres:16.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DB_NAME: gyrinx_replay
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_CONFIG: '{"user":"postgres","password":"postgres"}'
+      PR_NUMBER: ${{ matrix.pr.number }}
+      PR_SHA: ${{ matrix.pr.sha }}
+      REPORT_DIR: ${{ github.workspace }}/.migration-watch
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Merge the pull request into main in a throwaway tree
+        id: merge
+        continue-on-error: true
+        run: |
+          mkdir -p "$REPORT_DIR"
+          git config user.name "migration-watch"
+          git config user.email "migration-watch@users.noreply.github.com"
+          git fetch --no-tags origin "pull/$PR_NUMBER/head:refs/remotes/pr/$PR_NUMBER"
+          git checkout -q -b merged origin/main
+          git merge --no-edit --no-ff "refs/remotes/pr/$PR_NUMBER" 2>&1 | tee "$REPORT_DIR/merge.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      # The pull request's migrations and models are what is under test; the
+      # tooling that runs them and reports on them is always main's. Without
+      # this a branch could rewrite the action or the report script.
+      - name: Use main's tooling
+        if: steps.merge.outcome == 'success'
+        run: |
+          git checkout origin/main -- .github scripts
+          git commit -q -m "main's tooling" || true
+
+      - uses: ./.github/actions/python-env
+        if: steps.merge.outcome == 'success'
+
+      - name: Create an empty database
+        if: steps.merge.outcome == 'success'
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -U postgres -c 'CREATE DATABASE gyrinx_replay;'
+
+      # What the next container boot does after this pull request lands: the
+      # database already holds main, then the merge's migrations apply on top.
+      - name: Migrate main
+        id: replay_main
+        if: steps.merge.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 30
+        run: |
+          source .venv/bin/activate
+          git checkout -q origin/main
+          manage migrate 2>&1 | tee "$REPORT_DIR/replay-main.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      - name: Migrate the merge on top of main
+        id: replay
+        if: steps.replay_main.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 30
+        run: |
+          source .venv/bin/activate
+          git checkout -q merged
+          manage migrate 2>&1 | tee "$REPORT_DIR/replay.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      - name: Models and migrations agree
+        id: drift
+        if: steps.merge.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          git checkout -q merged
+          manage makemigrations --check --dry-run 2>&1 | tee "$REPORT_DIR/drift.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      - name: The branch adds one leaf per app
+        id: leaves
+        if: steps.merge.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          manage check_migration_conflicts --base origin/main 2>&1 | tee "$REPORT_DIR/leaves.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      - name: Branch migrations against what main gained
+        id: overlap
+        if: steps.merge.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          manage check_migration_overlap --base origin/main --head "refs/remotes/pr/$PR_NUMBER" \
+            --json "$REPORT_DIR/overlap.json" 2>&1 | tee "$REPORT_DIR/overlap.log"
+          test "${PIPESTATUS[0]}" -eq 0
+
+      # A pull request from a fork runs with a read-only token, so its own
+      # run cannot report; the fan-out from main covers it with a write token.
+      - name: Report on the pull request
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE: ${{ steps.merge.outcome }}
+          REPLAY_MAIN: ${{ steps.replay_main.outcome }}
+          REPLAY: ${{ steps.replay.outcome }}
+          DRIFT: ${{ steps.drift.outcome }}
+          LEAVES: ${{ steps.leaves.outcome }}
+          OVERLAP: ${{ steps.overlap.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 scripts/migration_watch_report.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,6 +463,36 @@ manage migrate
 SQL_DEBUG=True
 ```
 
+### Migrations on parallel branches
+
+An app's migration graph **may have several leaves**. Two branches that each add
+a migration to the same app merge in any order and deploy in any order; nothing
+is renamed or repointed, and the next migration anyone generates depends on
+every leaf and so joins them (`gyrinx/migration_graph.py` switches off
+Django's refusal and teaches `makemigrations` to depend on all leaves). Two
+files sharing a number prefix on main is cosmetic.
+
+- **Generate migrations with `manage makemigrations <app> -n <name>`; never type
+  the `dependencies` list yourself.** Generated dependencies name every leaf in
+  your tree. A hand-typed list that omits one lets the migration run before the
+  state it assumes. Edit the operations and the docstring afterwards if you like.
+- **After rebasing onto main there is nothing to do.** Your migration keeps its
+  name and its parent. Do not renumber, do not repoint, do not `--merge`.
+- **A branch adds at most one leaf per app.** `manage check_migration_conflicts`
+  (pre-commit and CI) fails when a branch adds two, which only happens with a
+  hand-written dependency list.
+- **Rename, delete or alter something another open branch touches, or run a data
+  migration against it, and the order matters.** The `Migration watch` workflow
+  re-checks every open migration PR each time main gains a migration: it merges
+  the branch into main, migrates a database to main and then to the merge (what
+  the next container boot does), runs `makemigrations --check` on the merge, and
+  reads the branch's migrations against the ones main gained since it forked. It
+  comments on the PR and sets a non-required `migration-watch` status. A ❌ there
+  means the next deploy would fail or two migrations change the same thing;
+  regenerate the migration on a checkout that includes current main. Run the
+  overlap check yourself with `manage check_migration_overlap --base origin/main`.
+- No coordination over migration numbers or parents is needed between agents.
+
 ### Production Database Access
 
 ```bash

--- a/docs/developing-gyrinx/models-and-database.md
+++ b/docs/developing-gyrinx/models-and-database.md
@@ -221,6 +221,30 @@ manage migrate
 - Consider migration dependencies between apps
 - Use data migrations for complex transformations
 
+### Parallel branches and the migration graph
+
+Django normally refuses to run while an app has two leaf migrations and asks
+for a merge migration. Gyrinx switches that refusal off (`gyrinx/migration_graph.py`)
+and makes `makemigrations` depend on every leaf of the app, so:
+
+- Two branches that each add a migration merge and deploy in any order. Nothing
+  is renamed or repointed. `migrate` applies every unapplied migration in
+  dependency order, which is all correctness needs.
+- The next generated migration depends on all the leaves and joins them.
+- Always generate the `dependencies` list with `makemigrations`. A hand-typed
+  list that omits a leaf can put a migration before the state it relies on.
+
+What no graph can see is two branches changing the same model or field, or a
+data migration reading what another branch changes. The `Migration watch`
+workflow (`.github/workflows/migration-watch.yml`) re-checks every open pull
+request with a migration whenever main gains one: it merges the branch into
+main, migrates a database to main and then to the merge, runs
+`makemigrations --check`, confirms the branch adds one leaf per app
+(`manage check_migration_conflicts`), and reads the branch's operations
+against those main gained since the branch forked
+(`manage check_migration_overlap`). Findings arrive as one comment on the
+pull request and a non-required `migration-watch` status.
+
 ## Performance Considerations
 
 ### Query Optimization

--- a/gyrinx/migration_graph.py
+++ b/gyrinx/migration_graph.py
@@ -23,7 +23,6 @@ from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.loader import MigrationLoader
 
 _django_arrange_for_graph = MigrationAutodetector.arrange_for_graph
-_django_detect_conflicts = MigrationLoader.detect_conflicts
 
 
 def detect_conflicts(self):

--- a/gyrinx/migration_graph.py
+++ b/gyrinx/migration_graph.py
@@ -1,0 +1,77 @@
+"""An app's migration graph may carry more than one leaf.
+
+Django refuses to ``migrate`` or ``makemigrations`` while an app has two leaf
+migrations, and offers a no-op merge migration as the cure. Neither the refusal
+nor the merge file is needed for correctness: ``migrate`` already applies every
+unapplied node in dependency order, and the project state is built from every
+leaf. What correctness does need is that a migration made on a tree with several
+leaves depends on all of them, so its operations can never run before the state
+they were generated against. That is the one change made here.
+
+With it, two branches that each add a migration to the same app merge in any
+order and deploy in any order, with no renaming and no repointing. The next
+migration anyone generates joins the leaves.
+
+The refusal lives at exactly two call sites in Django, both a policy check on
+``MigrationLoader.detect_conflicts()``; a test pins that so a Django upgrade
+that moves it is noticed.
+"""
+
+from __future__ import annotations
+
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.loader import MigrationLoader
+
+_django_arrange_for_graph = MigrationAutodetector.arrange_for_graph
+_django_detect_conflicts = MigrationLoader.detect_conflicts
+
+
+def detect_conflicts(self):
+    """Several leaves in one app are allowed; report none."""
+    return {}
+
+
+def arrange_for_graph(self, changes, graph, migration_name=None):
+    """Name the new migrations as Django does, then depend on every leaf.
+
+    Django appends the first leaf it finds for the app; the rest are added
+    here, so a migration generated on a forked tree joins the fork.
+    """
+    changes = _django_arrange_for_graph(self, changes, graph, migration_name)
+    for app_label, migrations in changes.items():
+        if not migrations:
+            continue
+        first = migrations[0]
+        for leaf in graph.leaf_nodes(app_label):
+            if leaf not in first.dependencies:
+                first.dependencies.append(leaf)
+        # A dependency on another app's leaf means "that app as it stands";
+        # when that app is forked, Django names one tip. Name them all.
+        for migration in migrations:
+            for dep in list(migration.dependencies):
+                if dep[0] == app_label or dep[1] in ("__first__", "__latest__"):
+                    continue
+                other_leaves = graph.leaf_nodes(dep[0])
+                if dep in other_leaves:
+                    for leaf in other_leaves:
+                        if leaf not in migration.dependencies:
+                            migration.dependencies.append(leaf)
+    return changes
+
+
+def allow_many_leaves():
+    """Install the policy. Idempotent; called from an AppConfig.ready()."""
+    MigrationLoader.detect_conflicts = detect_conflicts
+    MigrationAutodetector.arrange_for_graph = arrange_for_graph
+
+
+def leaves_added_since(leaves, base_names):
+    """The leaves of an app that are not migrations the base already has.
+
+    ``leaves`` are ``(app_label, name)`` keys; ``base_names`` the migration
+    names the base tree holds for that app. A branch may bring one new leaf
+    per app: its own chain's tip. Two means a migration was written by hand
+    on a tree whose other leaf it ignored, and its operations may run before
+    the state they assume.
+    """
+    return [leaf for leaf in leaves if leaf[1] not in base_names]

--- a/gyrinx/migration_overlap.py
+++ b/gyrinx/migration_overlap.py
@@ -1,0 +1,207 @@
+"""Find migrations on two branches that touch the same thing.
+
+Two migrations written on separate branches know nothing of each other. Most
+pairs are fine: each adds its own field or model, and the order they are
+applied in cannot matter. The pairs that can go wrong touch the same model or
+field, or one of them runs code against data the other changes. This module
+reads the operations of both sets and reports those pairs, so the author hears
+about it while the pull request is open rather than when a deploy fails.
+
+It is a static reading of ``operations``, not a proof: it names the model and
+field an operation declares, and for ``RunPython`` the models its source
+fetches with ``get_model``. Code that reaches a model some other way is
+reported as touching its whole app, which errs towards a warning.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from dataclasses import dataclass
+
+from django.db import migrations
+
+# Operations that change what an existing name refers to. Anything else on
+# the same model must be ordered against them.
+_MODEL_RESHAPING = {"DeleteModel", "RenameModel", "AlterModelTable"}
+
+_GET_MODEL = re.compile(
+    r"""get_model\(\s*['"](?P<app>\w+)['"]\s*,\s*['"](?P<model>\w+)['"]"""
+    r"""|get_model\(\s*['"](?P<dotted>\w+\.\w+)['"]"""
+)
+
+
+@dataclass(frozen=True)
+class Touch:
+    """One thing an operation reaches: a field, a model, or a whole app."""
+
+    app: str
+    model: str | None  # lower-cased; None when the scope could not be read
+    field: str | None
+    kind: str  # create, delete, reshape, add, remove, alter, meta, data
+    operation: str  # the operation class, for the report
+
+    def describe(self):
+        target = self.app
+        if self.model:
+            target += f".{self.model}"
+        if self.field:
+            target += f".{self.field}"
+        return f"{self.operation} on {target}"
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: (
+        str  # "blocks" — deploy or fresh database can fail; "review" — order may matter
+    )
+    base: tuple[str, str]
+    branch: tuple[str, str]
+    base_touch: Touch
+    branch_touch: Touch
+    reason: str
+
+
+def _fields_of(obj):
+    """Field names an index, constraint or option tuple names, if any."""
+    names = getattr(obj, "fields", None)
+    if names:
+        return [name.lstrip("-") for name in names]
+    return []
+
+
+def _touches_of_code(app_label, operation):
+    """Models a RunPython's forward function fetches; whole app if unreadable."""
+    try:
+        source = inspect.getsource(operation.code)
+    except OSError, TypeError:
+        source = ""
+    found = []
+    for match in _GET_MODEL.finditer(source):
+        if match.group("dotted"):
+            app, model = match.group("dotted").split(".")
+        else:
+            app, model = match.group("app"), match.group("model")
+        found.append(Touch(app, model.lower(), None, "data", "RunPython"))
+    if found:
+        return found
+    return [Touch(app_label, None, None, "data", "RunPython")]
+
+
+def touches(app_label, operation):
+    """Everything one operation reaches, as Touch records."""
+    name = type(operation).__name__
+    if isinstance(operation, migrations.SeparateDatabaseAndState):
+        return [
+            touch
+            for op in [*operation.database_operations, *operation.state_operations]
+            for touch in touches(app_label, op)
+        ]
+    if isinstance(operation, migrations.RunPython):
+        return _touches_of_code(app_label, operation)
+    if isinstance(operation, migrations.RunSQL):
+        return [Touch(app_label, None, None, "data", "RunSQL")]
+
+    model = getattr(operation, "model_name", None) or getattr(operation, "name", None)
+    if isinstance(operation, migrations.CreateModel):
+        return [Touch(app_label, operation.name.lower(), None, "create", name)]
+    if isinstance(operation, migrations.DeleteModel):
+        return [Touch(app_label, operation.name.lower(), None, "delete", name)]
+    if isinstance(operation, migrations.RenameModel):
+        return [
+            Touch(app_label, operation.old_name.lower(), None, "reshape", name),
+            Touch(app_label, operation.new_name.lower(), None, "reshape", name),
+        ]
+    if isinstance(operation, migrations.AlterModelTable):
+        return [Touch(app_label, operation.name.lower(), None, "reshape", name)]
+    if isinstance(operation, migrations.RenameField):
+        return [
+            Touch(app_label, model.lower(), operation.old_name, "reshape", name),
+            Touch(app_label, model.lower(), operation.new_name, "reshape", name),
+        ]
+    if isinstance(operation, migrations.AddField):
+        return [Touch(app_label, model.lower(), operation.name, "add", name)]
+    if isinstance(operation, migrations.RemoveField):
+        return [Touch(app_label, model.lower(), operation.name, "remove", name)]
+    if isinstance(operation, migrations.AlterField):
+        return [Touch(app_label, model.lower(), operation.name, "alter", name)]
+    if isinstance(operation, (migrations.AddIndex, migrations.AddConstraint)):
+        target = getattr(operation, "index", None) or getattr(
+            operation, "constraint", None
+        )
+        fields = _fields_of(target)
+        if fields:
+            return [Touch(app_label, model.lower(), f, "meta", name) for f in fields]
+        return [Touch(app_label, model.lower(), None, "meta", name)]
+    if isinstance(operation, migrations.AlterUniqueTogether):
+        fields = sorted({f for group in operation.unique_together or () for f in group})
+        if fields:
+            return [Touch(app_label, model.lower(), f, "meta", name) for f in fields]
+        return [Touch(app_label, model.lower(), None, "meta", name)]
+    if model:
+        # AlterModelOptions, AlterModelManagers, RemoveIndex, RemoveConstraint,
+        # AlterOrderWithRespectTo and any operation this module has not met.
+        return [Touch(app_label, str(model).lower(), None, "meta", name)]
+    return [Touch(app_label, None, None, "meta", name)]
+
+
+def _judge(a: Touch, b: Touch):
+    """Why two touches conflict, as (severity, reason); None when they don't."""
+    if a.app != b.app:
+        return None
+    if a.model is None or b.model is None:
+        # A data migration whose scope could not be read against anything in
+        # the same app, or two of them.
+        if a.kind == "data" or b.kind == "data":
+            return ("review", "a data migration whose scope could not be read")
+        return None
+    if a.model != b.model:
+        return None
+    if a.kind == "create" or b.kind == "create":
+        return ("blocks", "both branches create or reshape the same model")
+    if a.operation in _MODEL_RESHAPING or b.operation in _MODEL_RESHAPING:
+        return ("blocks", "one branch renames or deletes a model the other changes")
+    if a.kind == "data" or b.kind == "data":
+        return (
+            "review",
+            "a data migration runs against a model the other branch changes",
+        )
+    if a.field and b.field and a.field == b.field:
+        return ("blocks", "both branches change the same field")
+    if a.field is None and b.field is None and a.operation == b.operation:
+        return ("review", "both branches change the same model-level option")
+    return None
+
+
+def overlaps(base_migrations, branch_migrations):
+    """Findings for every conflicting pair between two sets of migrations.
+
+    Each argument maps ``(app_label, name)`` to a loaded ``Migration``.
+    """
+    base_touches = [
+        (key, touch)
+        for key, migration in base_migrations.items()
+        for op in migration.operations
+        for touch in touches(key[0], op)
+    ]
+    branch_touches = [
+        (key, touch)
+        for key, migration in branch_migrations.items()
+        for op in migration.operations
+        for touch in touches(key[0], op)
+    ]
+    found = []
+    seen = set()
+    for base_key, a in base_touches:
+        for branch_key, b in branch_touches:
+            verdict = _judge(a, b)
+            if verdict is None:
+                continue
+            severity, reason = verdict
+            signature = (base_key, branch_key, a, b)
+            if signature in seen:
+                continue
+            seen.add(signature)
+            found.append(Finding(severity, base_key, branch_key, a, b, reason))
+    found.sort(key=lambda f: (f.severity != "blocks", f.base, f.branch))
+    return found

--- a/gyrinx/tests/test_migration_graph.py
+++ b/gyrinx/tests/test_migration_graph.py
@@ -25,21 +25,28 @@ from gyrinx.migration_overlap import overlaps, touches
 def _forked_graph():
     graph = MigrationGraph()
     for key in [
-        ("shop", "0001_initial"),
-        ("shop", "0002_a"),
-        ("shop", "0002_b"),
+        ("orchard", "0001_initial"),
+        ("orchard", "0002_a"),
+        ("orchard", "0002_b"),
         ("other", "0001_initial"),
     ]:
         graph.add_node(key, None)
-    graph.add_dependency("shop.0002_a", ("shop", "0002_a"), ("shop", "0001_initial"))
-    graph.add_dependency("shop.0002_b", ("shop", "0002_b"), ("shop", "0001_initial"))
+    graph.add_dependency(
+        "orchard.0002_a", ("orchard", "0002_a"), ("orchard", "0001_initial")
+    )
+    graph.add_dependency(
+        "orchard.0002_b", ("orchard", "0002_b"), ("orchard", "0001_initial")
+    )
     return graph
 
 
 def test_a_forked_graph_is_not_a_conflict():
     loader = MigrationLoader(None, load=False)
     loader.graph = _forked_graph()
-    assert loader.graph.leaf_nodes("shop") == [("shop", "0002_a"), ("shop", "0002_b")]
+    assert loader.graph.leaf_nodes("orchard") == [
+        ("orchard", "0002_a"),
+        ("orchard", "0002_b"),
+    ]
     assert loader.detect_conflicts() == {}
 
 
@@ -56,16 +63,16 @@ def test_a_generated_migration_depends_on_every_leaf():
     detector = MigrationAutodetector(
         ProjectState(), ProjectState(), NonInteractiveMigrationQuestioner()
     )
-    new = Migration("auto_1", "shop")
+    new = Migration("auto_1", "orchard")
     new.operations = [
         migrations.AddField("item", "weight", models.IntegerField(default=0))
     ]
     changes = detector.arrange_for_graph(
-        {"shop": [new]}, _forked_graph(), migration_name="weight"
+        {"orchard": [new]}, _forked_graph(), migration_name="weight"
     )
-    (migration,) = changes["shop"]
+    (migration,) = changes["orchard"]
     assert migration.name == "0003_weight"
-    assert set(migration.dependencies) == {("shop", "0002_a"), ("shop", "0002_b")}
+    assert set(migration.dependencies) == {("orchard", "0002_a"), ("orchard", "0002_b")}
 
 
 def test_a_dependency_on_a_forked_app_names_every_tip():
@@ -74,7 +81,9 @@ def test_a_dependency_on_a_forked_app_names_every_tip():
         ProjectState(), ProjectState(), NonInteractiveMigrationQuestioner()
     )
     new = Migration("auto_1", "other")
-    new.dependencies = [("shop", "0002_a")]  # what Django resolves a cross-app dep to
+    new.dependencies = [
+        ("orchard", "0002_a")
+    ]  # what Django resolves a cross-app dep to
     new.operations = [
         migrations.AddField("thing", "item", models.IntegerField(default=0))
     ]
@@ -82,15 +91,15 @@ def test_a_dependency_on_a_forked_app_names_every_tip():
     (migration,) = changes["other"]
     assert set(migration.dependencies) == {
         ("other", "0001_initial"),
-        ("shop", "0002_a"),
-        ("shop", "0002_b"),
+        ("orchard", "0002_a"),
+        ("orchard", "0002_b"),
     }
 
 
 def test_a_branch_may_add_one_leaf():
-    leaves = [("shop", "0002_a"), ("shop", "0002_b")]
+    leaves = [("orchard", "0002_a"), ("orchard", "0002_b")]
     assert leaves_added_since(leaves, {"0001_initial", "0002_a"}) == [
-        ("shop", "0002_b")
+        ("orchard", "0002_b")
     ]
     assert len(leaves_added_since(leaves, {"0001_initial"})) == 2
 
@@ -102,7 +111,7 @@ def _migration(app, name, *operations):
 
 
 def _backfill(apps, schema_editor):
-    Item = apps.get_model("shop", "Item")
+    Item = apps.get_model("orchard", "Item")
     Item.objects.update(weight=1)
 
 
@@ -110,7 +119,7 @@ def test_two_additive_fields_do_not_overlap():
     base = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_a",
                 migrations.AddField("item", "price", models.IntegerField()),
             )
@@ -119,7 +128,7 @@ def test_two_additive_fields_do_not_overlap():
     branch = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_b",
                 migrations.AddField("item", "colour", models.IntegerField()),
             )
@@ -130,12 +139,12 @@ def test_two_additive_fields_do_not_overlap():
 
 def test_a_rename_against_a_field_change_blocks():
     base = dict(
-        [_migration("shop", "0002_a", migrations.RenameModel("Item", "Product"))]
+        [_migration("orchard", "0002_a", migrations.RenameModel("Item", "Product"))]
     )
     branch = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_b",
                 migrations.AddField("item", "colour", models.IntegerField()),
             )
@@ -143,15 +152,15 @@ def test_a_rename_against_a_field_change_blocks():
     )
     (finding,) = overlaps(base, branch)
     assert finding.severity == "blocks"
-    assert finding.base == ("shop", "0002_a")
-    assert finding.branch == ("shop", "0002_b")
+    assert finding.base == ("orchard", "0002_a")
+    assert finding.branch == ("orchard", "0002_b")
 
 
 def test_the_same_field_changed_twice_blocks():
     base = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_a",
                 migrations.AlterField("item", "price", models.IntegerField()),
             )
@@ -160,7 +169,7 @@ def test_the_same_field_changed_twice_blocks():
     branch = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_b",
                 migrations.AlterField("item", "price", models.FloatField()),
             )
@@ -174,7 +183,7 @@ def test_a_data_migration_on_a_changed_model_needs_review():
     base = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_a",
                 migrations.AddField("item", "weight", models.IntegerField()),
             )
@@ -183,7 +192,7 @@ def test_a_data_migration_on_a_changed_model_needs_review():
     branch = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_b",
                 migrations.RunPython(_backfill, migrations.RunPython.noop),
             )
@@ -198,7 +207,7 @@ def test_a_data_migration_on_another_app_is_left_alone():
     base = dict(
         [
             _migration(
-                "shop",
+                "orchard",
                 "0002_a",
                 migrations.AddField("item", "weight", models.IntegerField()),
             )
@@ -213,7 +222,7 @@ def test_a_data_migration_on_another_app_is_left_alone():
             )
         ]
     )
-    # The function fetches shop.Item, so the app it lives in does not matter.
+    # The function fetches orchard.Item, so the app it lives in does not matter.
     assert len(overlaps(base, branch)) == 1
     unrelated = dict([_migration("other", "0002_c", migrations.RunSQL("select 1"))])
     assert overlaps(base, unrelated) == []
@@ -222,7 +231,9 @@ def test_a_data_migration_on_another_app_is_left_alone():
 def test_separate_database_and_state_is_read_through():
     op = migrations.SeparateDatabaseAndState(
         state_operations=[migrations.AddField("item", "weight", models.IntegerField())],
-        database_operations=[migrations.RunSQL("alter table shop_item add weight int")],
+        database_operations=[
+            migrations.RunSQL("alter table orchard_item add weight int")
+        ],
     )
-    kinds = {t.kind for t in touches("shop", op)}
+    kinds = {t.kind for t in touches("orchard", op)}
     assert kinds == {"add", "data"}

--- a/gyrinx/tests/test_migration_graph.py
+++ b/gyrinx/tests/test_migration_graph.py
@@ -1,0 +1,228 @@
+"""The migration graph may fork; the tools around it hold the line.
+
+Three things are pinned here. Django's refusal to work on a forked graph is
+switched off, and a generated migration joins every leaf. Django still routes
+that refusal through the one method the switch replaces, so an upgrade that
+moves it fails here rather than silently bringing the refusal back. And the
+overlap reading tells an order-sensitive pair from a harmless one.
+"""
+
+import inspect
+
+from django.core.management.commands import makemigrations, migrate
+from django.db import migrations, models
+from django.db.migrations import Migration
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.graph import MigrationGraph
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
+from django.db.migrations.state import ProjectState
+
+from gyrinx.migration_graph import leaves_added_since
+from gyrinx.migration_overlap import overlaps, touches
+
+
+def _forked_graph():
+    graph = MigrationGraph()
+    for key in [
+        ("shop", "0001_initial"),
+        ("shop", "0002_a"),
+        ("shop", "0002_b"),
+        ("other", "0001_initial"),
+    ]:
+        graph.add_node(key, None)
+    graph.add_dependency("shop.0002_a", ("shop", "0002_a"), ("shop", "0001_initial"))
+    graph.add_dependency("shop.0002_b", ("shop", "0002_b"), ("shop", "0001_initial"))
+    return graph
+
+
+def test_a_forked_graph_is_not_a_conflict():
+    loader = MigrationLoader(None, load=False)
+    loader.graph = _forked_graph()
+    assert loader.graph.leaf_nodes("shop") == [("shop", "0002_a"), ("shop", "0002_b")]
+    assert loader.detect_conflicts() == {}
+
+
+def test_django_still_asks_the_loader_before_refusing():
+    # Both commands consult detect_conflicts() and nothing else; if a Django
+    # release moves the refusal, this fails and the switch needs following.
+    # The modules are read, not the classes: pytest-django swaps the migrate
+    # command for a subclass and the handle methods are wrapped by decorators.
+    assert inspect.getsource(migrate).count("detect_conflicts()") == 1
+    assert inspect.getsource(makemigrations).count("detect_conflicts()") == 1
+
+
+def test_a_generated_migration_depends_on_every_leaf():
+    detector = MigrationAutodetector(
+        ProjectState(), ProjectState(), NonInteractiveMigrationQuestioner()
+    )
+    new = Migration("auto_1", "shop")
+    new.operations = [
+        migrations.AddField("item", "weight", models.IntegerField(default=0))
+    ]
+    changes = detector.arrange_for_graph(
+        {"shop": [new]}, _forked_graph(), migration_name="weight"
+    )
+    (migration,) = changes["shop"]
+    assert migration.name == "0003_weight"
+    assert set(migration.dependencies) == {("shop", "0002_a"), ("shop", "0002_b")}
+
+
+def test_a_dependency_on_a_forked_app_names_every_tip():
+    graph = _forked_graph()
+    detector = MigrationAutodetector(
+        ProjectState(), ProjectState(), NonInteractiveMigrationQuestioner()
+    )
+    new = Migration("auto_1", "other")
+    new.dependencies = [("shop", "0002_a")]  # what Django resolves a cross-app dep to
+    new.operations = [
+        migrations.AddField("thing", "item", models.IntegerField(default=0))
+    ]
+    changes = detector.arrange_for_graph({"other": [new]}, graph, migration_name="x")
+    (migration,) = changes["other"]
+    assert set(migration.dependencies) == {
+        ("other", "0001_initial"),
+        ("shop", "0002_a"),
+        ("shop", "0002_b"),
+    }
+
+
+def test_a_branch_may_add_one_leaf():
+    leaves = [("shop", "0002_a"), ("shop", "0002_b")]
+    assert leaves_added_since(leaves, {"0001_initial", "0002_a"}) == [
+        ("shop", "0002_b")
+    ]
+    assert len(leaves_added_since(leaves, {"0001_initial"})) == 2
+
+
+def _migration(app, name, *operations):
+    m = Migration(name, app)
+    m.operations = list(operations)
+    return (app, name), m
+
+
+def _backfill(apps, schema_editor):
+    Item = apps.get_model("shop", "Item")
+    Item.objects.update(weight=1)
+
+
+def test_two_additive_fields_do_not_overlap():
+    base = dict(
+        [
+            _migration(
+                "shop",
+                "0002_a",
+                migrations.AddField("item", "price", models.IntegerField()),
+            )
+        ]
+    )
+    branch = dict(
+        [
+            _migration(
+                "shop",
+                "0002_b",
+                migrations.AddField("item", "colour", models.IntegerField()),
+            )
+        ]
+    )
+    assert overlaps(base, branch) == []
+
+
+def test_a_rename_against_a_field_change_blocks():
+    base = dict(
+        [_migration("shop", "0002_a", migrations.RenameModel("Item", "Product"))]
+    )
+    branch = dict(
+        [
+            _migration(
+                "shop",
+                "0002_b",
+                migrations.AddField("item", "colour", models.IntegerField()),
+            )
+        ]
+    )
+    (finding,) = overlaps(base, branch)
+    assert finding.severity == "blocks"
+    assert finding.base == ("shop", "0002_a")
+    assert finding.branch == ("shop", "0002_b")
+
+
+def test_the_same_field_changed_twice_blocks():
+    base = dict(
+        [
+            _migration(
+                "shop",
+                "0002_a",
+                migrations.AlterField("item", "price", models.IntegerField()),
+            )
+        ]
+    )
+    branch = dict(
+        [
+            _migration(
+                "shop",
+                "0002_b",
+                migrations.AlterField("item", "price", models.FloatField()),
+            )
+        ]
+    )
+    (finding,) = overlaps(base, branch)
+    assert finding.severity == "blocks"
+
+
+def test_a_data_migration_on_a_changed_model_needs_review():
+    base = dict(
+        [
+            _migration(
+                "shop",
+                "0002_a",
+                migrations.AddField("item", "weight", models.IntegerField()),
+            )
+        ]
+    )
+    branch = dict(
+        [
+            _migration(
+                "shop",
+                "0002_b",
+                migrations.RunPython(_backfill, migrations.RunPython.noop),
+            )
+        ]
+    )
+    (finding,) = overlaps(base, branch)
+    assert finding.severity == "review"
+    assert finding.branch_touch.model == "item"
+
+
+def test_a_data_migration_on_another_app_is_left_alone():
+    base = dict(
+        [
+            _migration(
+                "shop",
+                "0002_a",
+                migrations.AddField("item", "weight", models.IntegerField()),
+            )
+        ]
+    )
+    branch = dict(
+        [
+            _migration(
+                "other",
+                "0002_b",
+                migrations.RunPython(_backfill, migrations.RunPython.noop),
+            )
+        ]
+    )
+    # The function fetches shop.Item, so the app it lives in does not matter.
+    assert len(overlaps(base, branch)) == 1
+    unrelated = dict([_migration("other", "0002_c", migrations.RunSQL("select 1"))])
+    assert overlaps(base, unrelated) == []
+
+
+def test_separate_database_and_state_is_read_through():
+    op = migrations.SeparateDatabaseAndState(
+        state_operations=[migrations.AddField("item", "weight", models.IntegerField())],
+        database_operations=[migrations.RunSQL("alter table shop_item add weight int")],
+    )
+    kinds = {t.kind for t in touches("shop", op)}
+    assert kinds == {"add", "data"}

--- a/n23/core/apps.py
+++ b/n23/core/apps.py
@@ -17,6 +17,12 @@ class CoreConfig(AppConfig):
 
     def ready(self):
         """Import signal handlers when the app is ready."""
+        from gyrinx.migration_graph import allow_many_leaves
+
+        # Project-wide policy, installed here because this app owns the
+        # migration checks and every command runs after ready().
+        allow_many_leaves()
+
         import n23.core.checks  # noqa: F401
         import n23.core.events  # noqa: F401  — claims this edition's event nouns
         import n23.core.signals  # noqa: F401

--- a/n23/core/management/commands/check_migration_conflicts.py
+++ b/n23/core/management/commands/check_migration_conflicts.py
@@ -1,26 +1,104 @@
+"""Refuse a branch that adds more than one leaf to an app's migration graph.
+
+Several leaves per app are allowed on main: two branches that each added a
+migration merge without renaming or repointing, and the next generated
+migration joins them (see ``gyrinx.migration_graph``). What a single branch
+must not do is add two leaves of its own. ``makemigrations`` never does; a
+migration written by hand on a tree whose other leaf it ignored does, and its
+operations may then run before the state they assume.
+
+The base is a git ref, ``origin/main`` unless told otherwise. Without git, or
+without that ref, every leaf is reported and the check passes.
+"""
+
+import subprocess  # nosec B404 — runs fixed git commands to read the base tree
+
 from django.core.management.base import BaseCommand, CommandError
 from django.db.migrations.loader import MigrationLoader
 
+from gyrinx.migration_graph import leaves_added_since
+
+
+def migration_paths(loader):
+    """Repo-relative directory prefix of each migrated app's migrations package."""
+    prefixes = {}
+    for app_label in loader.migrated_apps:
+        module = loader.migrations_module(app_label)[0]
+        if module:
+            prefixes[module.replace(".", "/") + "/"] = app_label
+    return prefixes
+
+
+def _base_migration_names(base, loader):
+    """Migration names per app label in the base tree, or None without git."""
+    try:
+        listing = subprocess.run(  # nosec B603 B607 — fixed argv, no shell
+            ["git", "ls-tree", "-r", "--name-only", base],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except OSError, subprocess.CalledProcessError:
+        return None
+    prefixes = migration_paths(loader)
+    names = {}
+    for path in listing.splitlines():
+        if not path.endswith(".py") or path.endswith("/__init__.py"):
+            continue
+        for prefix, app_label in prefixes.items():
+            if path.startswith(prefix):
+                names.setdefault(app_label, set()).add(path[len(prefix) : -3])
+    return names
+
 
 class Command(BaseCommand):
-    help = "Check for conflicting migrations (multiple leaf nodes per app)."
+    help = "Refuse a branch that adds more than one migration leaf to an app."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--base",
+            default="origin/main",
+            help="Git ref whose migrations already count as merged (default origin/main).",
+        )
 
     def handle(self, *args, **options):
         loader = MigrationLoader(None, ignore_no_migrations=True)
-        conflicts = loader.detect_conflicts()
-
-        if not conflicts:
-            self.stdout.write("No migration conflicts detected.")
+        leaves_by_app = {}
+        for app_label, name in loader.graph.leaf_nodes():
+            leaves_by_app.setdefault(app_label, []).append((app_label, name))
+        forked = {
+            app: leaves for app, leaves in leaves_by_app.items() if len(leaves) > 1
+        }
+        if not forked:
+            self.stdout.write("Every app's migration graph has one leaf.")
             return
 
-        messages = []
-        for app_label, migration_names in sorted(conflicts.items()):
-            names = ", ".join(sorted(migration_names))
-            messages.append(f"  {app_label}: {names}")
+        base_names = _base_migration_names(options["base"], loader)
+        if base_names is None:
+            for app_label, leaves in sorted(forked.items()):
+                self.stdout.write(
+                    f"{app_label} has {len(leaves)} leaves; {options['base']} is not available, so none is checked."
+                )
+            return
 
-        raise CommandError(
-            "Conflicting migrations detected!\n" + "\n".join(messages) + "\n\n"
-            "These migrations branch from the same parent and need a "
-            "merge migration.\n"
-            "Run: manage makemigrations --merge"
-        )
+        failures = []
+        for app_label, leaves in sorted(forked.items()):
+            new = leaves_added_since(leaves, base_names.get(app_label, set()))
+            names = ", ".join(sorted(name for _, name in leaves))
+            if len(new) > 1:
+                failures.append(
+                    f"  {app_label}: this branch adds {len(new)} leaves — "
+                    + ", ".join(sorted(name for _, name in new))
+                )
+            else:
+                self.stdout.write(
+                    f"{app_label} has {len(leaves)} leaves ({names}); at most one is this branch's."
+                )
+        if failures:
+            raise CommandError(
+                "A branch may add one migration leaf per app.\n"
+                + "\n".join(failures)
+                + "\n\nA migration written on a tree with several leaves must depend on all of "
+                "them; `manage makemigrations` does this itself. Regenerate the newer migration, "
+                "or add the missing leaf to its dependencies."
+            )

--- a/n23/core/management/commands/check_migration_overlap.py
+++ b/n23/core/management/commands/check_migration_overlap.py
@@ -41,7 +41,7 @@ def _added_migrations(since, until, prefixes):
         since,
         until,
         "--",
-        "*/migrations/*.py",
+        ":(glob)**/migrations/*.py",
     )
     keys = []
     for path in listing.splitlines():

--- a/n23/core/management/commands/check_migration_overlap.py
+++ b/n23/core/management/commands/check_migration_overlap.py
@@ -69,6 +69,11 @@ class Command(BaseCommand):
         merge_base = _git("merge-base", options["base"], options["head"])
         base_keys = _added_migrations(merge_base, options["base"], prefixes)
         branch_keys = _added_migrations(merge_base, options["head"], prefixes)
+        # A file both sides added under one name is one migration after the
+        # merge, not a pair; a differing pair would have failed the merge.
+        shared = set(base_keys) & set(branch_keys)
+        base_keys = [key for key in base_keys if key not in shared]
+        branch_keys = [key for key in branch_keys if key not in shared]
 
         missing = [
             key

--- a/n23/core/management/commands/check_migration_overlap.py
+++ b/n23/core/management/commands/check_migration_overlap.py
@@ -1,0 +1,126 @@
+"""Report migrations on a branch that touch what main changed since it forked.
+
+Run in a tree that holds both sides — a merge of the branch into main, or the
+pull request's merge commit. The migrations main gained since the merge base
+and the migrations the branch adds are read from git; their operations are
+compared by ``gyrinx.migration_overlap``.
+
+Exit status is 1 when a pair can fail a deploy or a fresh database, 0 when
+every pair is clean or only needs a look. ``--json`` writes the findings for
+the pull request comment.
+"""
+
+import json
+import subprocess  # nosec B404 — runs fixed git commands to list changed files
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.migrations.loader import MigrationLoader
+
+from gyrinx.migration_overlap import overlaps
+
+from .check_migration_conflicts import migration_paths
+
+
+def _git(*args):
+    try:
+        return subprocess.run(  # nosec B603 B607 — fixed argv, no shell
+            ["git", *args], capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except subprocess.CalledProcessError as error:
+        raise CommandError(
+            f"git {' '.join(args)} failed: {error.stderr.strip()}"
+        ) from error
+
+
+def _added_migrations(since, until, prefixes):
+    """(app_label, name) for migration files added between two refs."""
+    listing = _git(
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        since,
+        until,
+        "--",
+        "*/migrations/*.py",
+    )
+    keys = []
+    for path in listing.splitlines():
+        if path.endswith("/__init__.py"):
+            continue
+        for prefix, app_label in prefixes.items():
+            if path.startswith(prefix):
+                keys.append((app_label, path[len(prefix) : -3]))
+    return keys
+
+
+class Command(BaseCommand):
+    help = "Report a branch's migrations that touch what main changed since it forked."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--base", default="origin/main", help="Main, as a git ref.")
+        parser.add_argument("--head", default="HEAD", help="The branch, as a git ref.")
+        parser.add_argument(
+            "--json", dest="json_path", help="Write the findings here as JSON."
+        )
+
+    def handle(self, *args, **options):
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+        prefixes = migration_paths(loader)
+        merge_base = _git("merge-base", options["base"], options["head"])
+        base_keys = _added_migrations(merge_base, options["base"], prefixes)
+        branch_keys = _added_migrations(merge_base, options["head"], prefixes)
+
+        missing = [
+            key
+            for key in [*base_keys, *branch_keys]
+            if key not in loader.disk_migrations
+        ]
+        if missing:
+            raise CommandError(
+                "These migrations are not in the working tree; run this in a tree that holds both sides: "
+                + ", ".join(f"{app}.{name}" for app, name in missing)
+            )
+
+        base = {key: loader.disk_migrations[key] for key in base_keys}
+        branch = {key: loader.disk_migrations[key] for key in branch_keys}
+        found = overlaps(base, branch)
+
+        report = {
+            "base_migrations": [f"{app}.{name}" for app, name in sorted(base_keys)],
+            "branch_migrations": [f"{app}.{name}" for app, name in sorted(branch_keys)],
+            "findings": [
+                {
+                    "severity": f.severity,
+                    "base": f"{f.base[0]}.{f.base[1]}",
+                    "branch": f"{f.branch[0]}.{f.branch[1]}",
+                    "base_operation": f.base_touch.describe(),
+                    "branch_operation": f.branch_touch.describe(),
+                    "reason": f.reason,
+                }
+                for f in found
+            ],
+        }
+        if options["json_path"]:
+            with open(options["json_path"], "w", encoding="utf-8") as handle:
+                json.dump(report, handle, indent=2)
+
+        if not base_keys:
+            self.stdout.write("Main has gained no migration since this branch forked.")
+            return
+        if not branch_keys:
+            self.stdout.write("This branch adds no migration.")
+            return
+        if not found:
+            self.stdout.write(
+                f"{len(branch_keys)} branch migration(s) and {len(base_keys)} new on main touch nothing in common."
+            )
+            return
+        for f in found:
+            self.stdout.write(
+                f"[{f.severity}] main {f.base[0]}.{f.base[1]} ({f.base_touch.describe()}) "
+                f"vs branch {f.branch[0]}.{f.branch[1]} ({f.branch_touch.describe()}): {f.reason}"
+            )
+        if any(f.severity == "blocks" for f in found):
+            raise CommandError(
+                "A migration on this branch collides with one main gained since it forked."
+            )

--- a/scripts/check_migration_conflicts.sh
+++ b/scripts/check_migration_conflicts.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 #
-# Check for conflicting Django migrations using Django's own
-# MigrationLoader.detect_conflicts().
+# Refuse a branch that adds more than one migration leaf to an app.
 #
-# This catches the real problem: multiple leaf nodes in a single app's
-# migration graph (i.e. two migrations that both claim to follow the
-# same parent, requiring a merge migration).  This is strictly better
-# than checking for duplicate numeric prefixes, because two PRs can
-# create migrations with *different* numbers that still conflict.
+# Several leaves per app are allowed on main (see gyrinx/migration_graph.py):
+# branches merge without renaming or repointing and the next generated
+# migration joins them. A single branch adding two leaves means a migration
+# was written by hand on a tree whose other leaf it ignored.
 #
-# Requires Django to be importable (run inside the virtualenv or CI
-# after `uv sync`).
+# Compares against origin/main unless MIGRATION_BASE says otherwise. Requires
+# Django to be importable (run inside the virtualenv or CI after `uv sync`).
 
 set -euo pipefail
 
-python scripts/manage.py check_migration_conflicts
+python scripts/manage.py check_migration_conflicts --base "${MIGRATION_BASE:-origin/main}"

--- a/scripts/migration_watch_report.py
+++ b/scripts/migration_watch_report.py
@@ -51,10 +51,17 @@ def outcome(name):
     return os.environ.get(name, "skipped")
 
 
-def build(report_dir, pr_number, run_url):
-    """Return (state, headline, body). state is success | failure | pending."""
+def build(report_dir):
+    """Return (state, headline, problems, notes); state is a commit-status state."""
     problems = []
     notes = []
+
+    if outcome("FETCH") != "success":
+        notes.append(
+            "The branch could not be fetched, so nothing was checked.\n\n"
+            f"```\n{tail(report_dir / 'fetch.log')}\n```"
+        )
+        return "error", "could not fetch the branch", problems, notes
 
     if outcome("MERGE") != "success":
         problems.append(
@@ -63,7 +70,12 @@ def build(report_dir, pr_number, run_url):
         )
         return "failure", "conflicts with main", problems, notes
 
-    if outcome("REPLAY_MAIN") != "success":
+    if outcome("REPLAY_MAIN") == "skipped":
+        notes.append(
+            "The environment or the database could not be set up, so the deploy replay did not run. "
+            "That is the runner's problem, not this pull request's."
+        )
+    elif outcome("REPLAY_MAIN") != "success":
         notes.append(
             "Main itself did not migrate on an empty database, so the deploy replay could not run. "
             f"That is main's problem, not this pull request's.\n\n```\n{tail(report_dir / 'replay-main.log')}\n```"
@@ -130,11 +142,14 @@ def build(report_dir, pr_number, run_url):
 
 def render(state, headline, problems, notes, run_url, main_sha):
     lines = [MARKER, f"### Migration watch: {headline}", ""]
-    lines.append(
-        f"Checked against main at `{main_sha[:10]}`: merged this branch into main, migrated a database to "
-        "main and then to the merge, compared models with migrations, and read this branch's migrations "
-        f"against the ones main gained since it forked. [Run]({run_url})."
-    )
+    if state == "error":
+        lines.append(f"[Run]({run_url}).")
+    else:
+        lines.append(
+            f"Checked against main at `{main_sha[:10]}`: merged this branch into main, migrated a database to "
+            "main and then to the merge, compared models with migrations, and read this branch's migrations "
+            f"against the ones main gained since it forked. [Run]({run_url})."
+        )
     lines.append("")
     if problems:
         lines.append("\n\n".join(problems))
@@ -186,7 +201,7 @@ def main():
         or "main"
     )
 
-    state, headline, problems, notes = build(report_dir, pr_number, run_url)
+    state, headline, problems, notes = build(report_dir)
     body = render(state, headline, problems, notes, run_url, main_sha)
     print(body)
 

--- a/scripts/migration_watch_report.py
+++ b/scripts/migration_watch_report.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Write the migration-watch result onto a pull request.
+
+Reads the step outcomes and logs the workflow left in ``REPORT_DIR``, then
+keeps one comment on the pull request up to date (found by a marker, edited in
+place) and sets a non-required status on the head commit. A pull request that
+is clean and has never been commented on is left alone; one that was flagged
+before is told it is clear now.
+
+Standard library only; the workflow runs it on the runner's Python with the
+``gh`` CLI on the path.
+"""
+
+import json
+import os
+import pathlib
+import subprocess  # nosec B404 — calls the gh CLI with fixed arguments
+import sys
+
+MARKER = "<!-- migration-watch -->"
+CONTEXT = "migration-watch"
+LOG_TAIL = 30
+
+
+def gh(*args, input_text=None):
+    result = subprocess.run(  # nosec B603 B607 — fixed argv, no shell
+        ["gh", *args], capture_output=True, text=True, input=input_text
+    )
+    if result.returncode:
+        print(
+            f"gh {' '.join(args[:3])}… failed: {result.stderr.strip()}", file=sys.stderr
+        )
+        return None
+    return result.stdout
+
+
+def tail(path):
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    lines = [
+        line
+        for line in lines
+        if not line.startswith("DEBUG ") and "pkg_resources" not in line
+    ]
+    return "\n".join(lines[-LOG_TAIL:])
+
+
+def outcome(name):
+    return os.environ.get(name, "skipped")
+
+
+def build(report_dir, pr_number, run_url):
+    """Return (state, headline, body). state is success | failure | pending."""
+    problems = []
+    notes = []
+
+    if outcome("MERGE") != "success":
+        problems.append(
+            "**Does not merge into main.** Git reports a conflict; the checks below need a merge to run.\n\n"
+            f"```\n{tail(report_dir / 'merge.log')}\n```"
+        )
+        return "failure", "conflicts with main", problems, notes
+
+    if outcome("REPLAY_MAIN") != "success":
+        notes.append(
+            "Main itself did not migrate on an empty database, so the deploy replay could not run. "
+            f"That is main's problem, not this pull request's.\n\n```\n{tail(report_dir / 'replay-main.log')}\n```"
+        )
+    elif outcome("REPLAY") != "success":
+        problems.append(
+            "**The next deploy would fail.** A database holding main did not accept this pull request's "
+            f"migrations on top.\n\n```\n{tail(report_dir / 'replay.log')}\n```"
+        )
+
+    if outcome("DRIFT") != "success":
+        problems.append(
+            "**The merged models and migrations disagree.** `makemigrations --check` on the merge:\n\n"
+            f"```\n{tail(report_dir / 'drift.log')}\n```"
+        )
+
+    if outcome("LEAVES") != "success":
+        problems.append(
+            "**This branch adds more than one migration leaf to an app.**\n\n"
+            f"```\n{tail(report_dir / 'leaves.log')}\n```"
+        )
+
+    overlap_path = report_dir / "overlap.json"
+    if overlap_path.exists():
+        overlap = json.loads(overlap_path.read_text(encoding="utf-8"))
+        blocks = [f for f in overlap["findings"] if f["severity"] == "blocks"]
+        review = [f for f in overlap["findings"] if f["severity"] != "blocks"]
+        if blocks or review:
+            rows = ["| | Main gained | This branch | Why |", "|---|---|---|---|"]
+            for f in [*blocks, *review]:
+                flag = "❌" if f["severity"] == "blocks" else "⚠️"
+                rows.append(
+                    f"| {flag} | `{f['base']}`<br>{f['base_operation']} "
+                    f"| `{f['branch']}`<br>{f['branch_operation']} | {f['reason']} |"
+                )
+            text = "\n".join(rows)
+            if blocks:
+                problems.append(
+                    "**A migration here touches what main changed since this branch forked.** "
+                    "Neither migration knows about the other, so the order they apply in is whichever "
+                    "merges first.\n\n" + text
+                )
+            else:
+                notes.append(
+                    "A data migration here runs against something main changed since this branch "
+                    "forked. Check that the order does not matter.\n\n" + text
+                )
+    elif outcome("OVERLAP") != "success":
+        notes.append(
+            f"The overlap check did not run:\n\n```\n{tail(report_dir / 'overlap.log')}\n```"
+        )
+
+    if problems:
+        return (
+            "failure",
+            f"{len(problems)} problem(s) against current main",
+            problems,
+            notes,
+        )
+    if notes:
+        return "success", "clear, with a note", problems, notes
+    return "success", "clear against current main", problems, notes
+
+
+def render(state, headline, problems, notes, run_url, main_sha):
+    lines = [MARKER, f"### Migration watch: {headline}", ""]
+    lines.append(
+        f"Checked against main at `{main_sha[:10]}`: merged this branch into main, migrated a database to "
+        "main and then to the merge, compared models with migrations, and read this branch's migrations "
+        f"against the ones main gained since it forked. [Run]({run_url})."
+    )
+    lines.append("")
+    if problems:
+        lines.append("\n\n".join(problems))
+        lines.append("")
+        lines.append(
+            "How to fix: regenerate the migration on a checkout that includes current main "
+            "(`manage makemigrations <app> -n <name>`), or add main's leaf to its `dependencies` "
+            "so it applies after what it relies on. No renaming is needed."
+        )
+    if notes:
+        lines.append("")
+        lines.append("\n\n".join(notes))
+    if not problems and not notes:
+        lines.append("Nothing here collides with main any more.")
+    lines.append("")
+    lines.append(
+        "_Re-run automatically when main gains a migration or this branch changes._"
+    )
+    return "\n".join(lines)
+
+
+def existing_comment(repo, pr_number):
+    page = 1
+    while True:
+        out = gh(
+            "api", f"repos/{repo}/issues/{pr_number}/comments?per_page=100&page={page}"
+        )
+        if not out:
+            return None
+        comments = json.loads(out)
+        for comment in comments:
+            if MARKER in (comment.get("body") or ""):
+                return comment["id"]
+        if len(comments) < 100:
+            return None
+        page += 1
+
+
+def main():
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pr_number = os.environ["PR_NUMBER"]
+    sha = os.environ["PR_SHA"]
+    run_url = os.environ.get("RUN_URL", "")
+    report_dir = pathlib.Path(os.environ.get("REPORT_DIR", ".migration-watch"))
+    main_sha = (
+        subprocess.run(  # nosec B603 B607 — fixed argv, no shell
+            ["git", "rev-parse", "origin/main"], capture_output=True, text=True
+        ).stdout.strip()
+        or "main"
+    )
+
+    state, headline, problems, notes = build(report_dir, pr_number, run_url)
+    body = render(state, headline, problems, notes, run_url, main_sha)
+    print(body)
+
+    comment_id = existing_comment(repo, pr_number)
+    if comment_id:
+        gh(
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{repo}/issues/comments/{comment_id}",
+            "-f",
+            f"body={body}",
+        )
+    elif problems or notes:
+        gh(
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "-f",
+            f"body={body}",
+        )
+
+    gh(
+        "api",
+        "--method",
+        "POST",
+        f"repos/{repo}/statuses/{sha}",
+        "-f",
+        f"state={state}",
+        "-f",
+        f"context={CONTEXT}",
+        "-f",
+        f"description={headline[:140]}",
+        "-f",
+        f"target_url={run_url}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migration_watch_report.py
+++ b/scripts/migration_watch_report.py
@@ -99,8 +99,13 @@ def build(report_dir):
         )
 
     overlap_path = report_dir / "overlap.json"
+    overlap = None
     if overlap_path.exists():
-        overlap = json.loads(overlap_path.read_text(encoding="utf-8"))
+        try:
+            overlap = json.loads(overlap_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as error:
+            notes.append(f"The overlap findings could not be read: {error}")
+    if overlap is not None:
         blocks = [f for f in overlap["findings"] if f["severity"] == "blocks"]
         review = [f for f in overlap["findings"] if f["severity"] != "blocks"]
         if blocks or review:

--- a/scripts/migration_watch_report.py
+++ b/scripts/migration_watch_report.py
@@ -80,19 +80,19 @@ def build(report_dir):
             "Main itself did not migrate on an empty database, so the deploy replay could not run. "
             f"That is main's problem, not this pull request's.\n\n```\n{tail(report_dir / 'replay-main.log')}\n```"
         )
-    elif outcome("REPLAY") != "success":
+    elif outcome("REPLAY") == "failure":
         problems.append(
             "**The next deploy would fail.** A database holding main did not accept this pull request's "
             f"migrations on top.\n\n```\n{tail(report_dir / 'replay.log')}\n```"
         )
 
-    if outcome("DRIFT") != "success":
+    if outcome("DRIFT") == "failure":
         problems.append(
             "**The merged models and migrations disagree.** `makemigrations --check` on the merge:\n\n"
             f"```\n{tail(report_dir / 'drift.log')}\n```"
         )
 
-    if outcome("LEAVES") != "success":
+    if outcome("LEAVES") == "failure":
         problems.append(
             "**This branch adds more than one migration leaf to an app.**\n\n"
             f"```\n{tail(report_dir / 'leaves.log')}\n```"
@@ -128,7 +128,7 @@ def build(report_dir):
                     "A data migration here runs against something main changed since this branch "
                     "forked. Check that the order does not matter.\n\n" + text
                 )
-    elif outcome("OVERLAP") != "success":
+    elif outcome("OVERLAP") == "failure":
         notes.append(
             f"The overlap check did not run:\n\n```\n{tail(report_dir / 'overlap.log')}\n```"
         )


### PR DESCRIPTION
## Summary

- Django's refusal to run while an app has two leaf migrations is switched off project-wide (`gyrinx/migration_graph.py`). Two branches that each add a migration now merge and deploy in any order. Nothing is renamed or repointed.
- `makemigrations` makes a new migration depend on every leaf of its app, and on every tip of a forked app it depends on. The next generated migration joins the fork.
- `check_migration_conflicts` now fails only when one branch adds more than one new leaf to an app. `check_migration_overlap` reports a branch migration that touches what main changed since the branch forked.
- The `Migration watch` workflow re-checks every open pull request that adds a migration each time main gains one. It comments on the pull request and sets a non-required `migration-watch` status.

## Why this is safe

`migrate` applies every unapplied migration in dependency order, and Django builds the project state from all leaves. A migration's operations were generated against its ancestors' state. A migration generated on a forked tree now names every leaf as an ancestor. The refusal was a policy check at two call sites, `migrate` and `makemigrations`. A test pins those call sites so a Django upgrade that moves them fails loudly.

A scratch project ran three agents through all 20 valid merge orders, with a deploy after every merge and a fresh database at the end. One agent rebased part way and added a second migration. One shipped a two-migration stack. Zero failures.

## What the graph cannot see

Two branches changing the same model or field, or a data migration reading what another branch changes, is a clash no graph scheme detects. On a forked graph the order they apply in is whichever merged first. The watch covers it. For each pull request, in a throwaway merge into main, it:

1. Migrates an empty database to main, then to the merge. This is what the next container boot does.
2. Runs `makemigrations --check` on the merge.
3. Runs the leaf check and the overlap check.

Example: a `RenameModel(Pickable)` leaf against a migration that alters a Pickable field fails `migrate` with a `KeyError` in one apply order and passes in the other. The replay and drift steps catch it. The overlap step names the pair.

The branch's own code runs in the job. So the checkout does not persist the token. Main's tooling is restored before the report step, and only that step receives the token.

## Not in this PR

- "Require branches up to date" stays off. The watch replaces it.
- No agent review of two `RunPython` migrations on the same model. The overlap check flags the pair for a person.

## Test plan

- [x] `pytest gyrinx/tests/test_migration_graph.py`
- [x] Full suite green (10396 passed, 12 skipped, 1 xfailed)
- [x] Smoke test on this repo: two leaf migrations in `library`; `migrate` runs; `makemigrations --dry-run -v3` depends on both; the deploy-order replay passes; both commands report as expected
- [ ] The workflow does not run on this pull request, which touches nothing under `migrations/`. It first runs on the next pull request that adds a migration, or via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
