### PR TITLE
feat: seed the Power Boost table as standard content with rated results

### DIFF
--- a/.claude/notes/issue-2313-plan.md
+++ b/.claude/notes/issue-2313-plan.md
@@ -323,10 +323,19 @@ test ends with `assert_reconciled(gang)`.
    carries hosted-alongside rows to the carrier's new host; gang-held picks
    stay put. Same PR.
 3. **The Power Boost table.** Seeded in `standard_content.py` beside the
-   glitch table, the slot attached to the Spyrer subtype, the stored spend on
-   each result. Tests with loaded dice: band 1 offers two members, four Kill
-   Count goes, the rating moves by the table's figure, a capped result can be
-   substituted, and the slot survives the count dropping below four.
+   glitch table as `power-boost-table`: slot type, D6 band table, the two
+   Combat Neuroware results told apart by annotation, `rating_contribution`
+   on each result, a standing choice of up to twenty picks. Following the
+   lasting-tables doctrine (names and numbers only), the characteristic
+   modifiers, the stored Kill Count spend and the gang-type grant are
+   authoring steps written into `recipes.md` ("Suit Evolution"), and
+   `n26/tests/sandbox/test_power_boost.py` performs them with the verbs and
+   proves the flow: band 1 offers two members, four Kill Count goes, the
+   rating moves by the table's figure, a capped result is substituted by
+   the player, the choice survives the count dropping below four, and a
+   result taken back drops its rating but not the spend. Stat limits
+   (library 0093) now clamp a capped characteristic, so a wasted result
+   reads as no change rather than a breach.
 4. **Clear glitches.** Route, dialog, the two tallies and the removals.
    Tests: the count zeroes, the penalty picks go, the history reads.
 5. **Words and drawing.** The note on the augmentation choice, the Hunt

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -402,7 +402,8 @@ the owner decides when to roll.
    band with the credits it adds to the model's rating, and a standing
    choice of up to twenty picks. The first band contains two results,
    one for Weapon Skill and one for Ballistic Skill, because the book
-   lets the player raise either.
+   lets the player raise either. The table's page says a roll of 1 is
+   claimed by more than one result. That is the book, not a mistake.
 2. Give Spyrers a **Kill Count** counter if they do not have one: create
    the counter and build it into each Spyrer entry, starting at 0. The
    Glitch Count is built the same way.

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -385,6 +385,58 @@ page. The reverse is a valid setup rather than a mistake: place the
 family and offer nothing, and the model may select powers from it at any
 time but is not given a first one.
 
+## Suit Evolution: the Power Boost table
+
+> Draft, for review.
+
+A Spyrer's suit keeps a Kill Count. After a battle, a Spyrer with a Kill
+Count of four or more may spend four and roll a D6 for a Power Boost.
+Rolls of 1 to 4 raise a characteristic; a 5 or 6 raises one carried
+item's augmentation level. Each result raises the model's rating by a
+printed figure. The app rolls only when asked, and never checks the Kill
+Count: the Power Boost line is on the card whatever the count is, and
+the owner decides when to roll.
+
+1. On **Foundations**, create the **Power Boost table**. One click
+   creates the slot type with *allows repeats* on, every result at its
+   band with the credits it adds to the model's rating, and a standing
+   choice of up to twenty picks. The first band contains two results,
+   one for Weapon Skill and one for Ballistic Skill, because the book
+   lets the player raise either.
+2. Give Spyrers a **Kill Count** counter if they do not have one: create
+   the counter and build it into each Spyrer entry, starting at 0. The
+   Glitch Count is built the same way.
+3. Standard content carries names and numbers only, so finish the
+   results by hand. On each result that raises a characteristic, attach
+   a **modifier**: targets the model, improves that characteristic by
+   one (Weapon Skill or Ballistic Skill for the two Combat Neuroware
+   results, Initiative, Movement, Save). The characteristic's own
+   maximum stops the change. When that happens the book counts the
+   result as Hunting Rig Augmentation instead; that is the player's to
+   apply. The picker offers every result whatever was rolled.
+4. On every result, attach a **modifier** as well: targets the model,
+   *moves a counter* — the Kill Count, down by four. It runs once, when
+   the result is picked, and taking the result back later does not give
+   the four back.
+5. On the Spyre Hunters gang type, attach a **modifier**: targets *all
+   models in the gang*, narrowed to those that have the **Spyrer**
+   subtype, and *gives* the Power Boost choice. Do not narrow it by the
+   Kill Count: if the choice disappeared when the count dropped below
+   four, every result already picked would go with it.
+
+A Spyrer's card then shows a Power Boost line, and its picker offers to
+roll. Rolling writes the roll to the gang's history; picking a result
+adds it to the card, takes four from the Kill Count, and raises the
+model's rating by the result's figure. Hunting Rig Augmentation raises
+no characteristic on its own: the player then opens the augmentation
+choice on one of the Spyrer's items and adds a tier there. Rolling again
+is a second pick; taking a result back removes its rating and nothing
+else.
+
+Clearing all glitches instead of rolling is not yet a single action:
+take the glitch results off the card by hand and move the Kill Count
+down by four.
+
 ## The Lasting Injury and Lasting Damage tables
 
 > Draft, for review.

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -1397,6 +1397,109 @@ def _grants_escape(pickable, slot):
     pickable.modifiers.add(row)
 
 
+#: Suit Evolution's roll (Spyre Hunting Party gang list): a Spyrer spends
+#: four Kill Count and rolls a D6 on the Power Boost table. Each result
+#: raises the model's credit value by a printed figure, so each carries
+#: that figure as its rating contribution — a pick is never paid for, and
+#: this is what the model is worth once it lands. The first band lists two
+#: results, because the book lets the player raise Weapon Skill or
+#: Ballistic Skill; the two are told apart by annotation. Results 5 and 6
+#: are one line: raise one carried item's augmentation level, which the
+#: player does on that item's own choice.
+POWER_BOOST_SLOT_TYPE = "Power Boost"
+#: ``(low, high, result, annotation, credits the result adds to rating)``
+POWER_BOOST_TABLE = [
+    (1, 1, "Combat Neuroware", "WS", 20),
+    (1, 1, "Combat Neuroware", "BS", 20),
+    (2, 2, "Heightened Reactions", "", 10),
+    (3, 3, "Improved Motive Power", "", 10),
+    (4, 4, "Thickened Armour", "", 15),
+    (5, 6, "Hunting Rig Augmentation", "", 20),
+]
+
+
+def _power_boost_result(slot_type, name, annotation, rating):
+    """One result, matched by name and annotation under its own slot
+    type; a name another slot type already claims is refused in words,
+    as the lasting tables do. The annotation doubles as the qualifier so
+    two results of one name are two rows under the per-pack constraint."""
+    from n26.library.models import Pickable
+
+    own = Pickable.objects.filter(
+        name__iexact=name, annotation__iexact=annotation, slot_type=slot_type
+    ).first()
+    if own is not None:
+        return own
+    taken = Pickable.objects.filter(
+        name__iexact=name, qualifier__iexact=annotation
+    ).first()
+    if taken is not None:
+        raise RuntimeError(
+            f'A pickable named "{name}" already belongs to the '
+            f'"{taken.slot_type}" slot type, so the "{slot_type}" table '
+            "cannot claim the name."
+        )
+    return Pickable.objects.create(
+        name=name,
+        annotation=annotation,
+        qualifier=annotation,
+        slot_type=slot_type,
+        rating_contribution=rating,
+    )
+
+
+def _create_power_boost_table():
+    from n26.library.models import Picklist, PicklistMember, Slot, SlotType
+
+    slot_type = SlotType.objects.filter(name__iexact=POWER_BOOST_SLOT_TYPE).first()
+    if slot_type is None:
+        slot_type = SlotType.objects.create(
+            name=POWER_BOOST_SLOT_TYPE,
+            plural_name="Power Boosts",
+            allows_repeats=True,
+        )
+    table_name = f"{POWER_BOOST_SLOT_TYPE} Table"
+    table = Picklist.objects.filter(
+        slot_type=slot_type, name__iexact=table_name
+    ).first()
+    if table is None:
+        table = Picklist.objects.create(
+            name=table_name, slot_type=slot_type, dice="d6", roll_selects="band"
+        )
+    for position, (low, high, result, annotation, rating) in enumerate(
+        POWER_BOOST_TABLE
+    ):
+        pickable = _power_boost_result(slot_type, result, annotation, rating)
+        PicklistMember.objects.get_or_create(
+            picklist=table,
+            pickable=pickable,
+            defaults={"roll_low": low, "roll_high": high, "position": position},
+        )
+    _lasting_row(
+        Slot,
+        POWER_BOOST_SLOT_TYPE,
+        "",
+        slot_type,
+        {
+            "picklist": table,
+            "label": POWER_BOOST_SLOT_TYPE,
+            "min_picks": 0,
+            "max_picks": 20,
+        },
+    )
+
+
+def _check_power_boost_table():
+    from n26.library.models import PicklistMember, Slot, SlotType
+
+    present = _count(SlotType, name__iexact=POWER_BOOST_SLOT_TYPE)
+    present += _count(
+        PicklistMember, picklist__name__iexact=f"{POWER_BOOST_SLOT_TYPE} Table"
+    )
+    present += _count(Slot, name__iexact=POWER_BOOST_SLOT_TYPE)
+    return present, 1 + len(POWER_BOOST_TABLE) + 1
+
+
 def _status_modifier(pickable, status):
     """Attach "marks the model <status>" to a result, once.
 
@@ -1474,6 +1577,21 @@ STANDARD_CONTENT = {
             ),
             check=_check_lasting_effect_tables,
             create=_create_lasting_effect_tables,
+        ),
+        StandardContent(
+            key="power-boost-table",
+            name="Power Boost table",
+            help=(
+                "The Spyre Hunters' Power Boost as a roll table — a slot "
+                "type, its results at their bands, the credits each result "
+                "adds to the model's rating, and a standing choice. Names, "
+                "bands and ratings only: results that raise a characteristic "
+                "still need their modifiers attached, every result needs one "
+                "that moves the Kill Count down by four, and the Spyre "
+                "Hunters gang type a modifier that gives Spyrers the choice."
+            ),
+            check=_check_power_boost_table,
+            create=_create_power_boost_table,
         ),
         StandardContent(
             key="core-subtypes",

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -1459,7 +1459,10 @@ def _power_boost_result(slot_type, name, annotation, rating):
 def _create_power_boost_table():
     from n26.library.models import Picklist, PicklistMember, Slot, SlotType
 
-    slot_type = SlotType.objects.filter(name__iexact=POWER_BOOST_SLOT_TYPE).first()
+    # The default pack's slot type, never a homebrew pack's of the same
+    # name: names are unique per pack, and the table belongs with the
+    # standard content it is seeded beside.
+    slot_type = _by_name(SlotType, POWER_BOOST_SLOT_TYPE)
     if slot_type is None:
         slot_type = SlotType.objects.create(
             name=POWER_BOOST_SLOT_TYPE,
@@ -1498,13 +1501,18 @@ def _create_power_boost_table():
 
 
 def _check_power_boost_table():
+    from django.conf import settings
+
     from n26.library.models import PicklistMember, Slot, SlotType
 
-    present = _count(SlotType, name__iexact=POWER_BOOST_SLOT_TYPE)
+    pack = settings.DEFAULT_CONTENT_PACK_SLUG
+    present = _count(SlotType, name__iexact=POWER_BOOST_SLOT_TYPE, pack__slug=pack)
     present += _count(
-        PicklistMember, picklist__name__iexact=f"{POWER_BOOST_SLOT_TYPE} Table"
+        PicklistMember,
+        picklist__name__iexact=f"{POWER_BOOST_SLOT_TYPE} Table",
+        picklist__pack__slug=pack,
     )
-    present += _count(Slot, name__iexact=POWER_BOOST_SLOT_TYPE)
+    present += _count(Slot, name__iexact=POWER_BOOST_SLOT_TYPE, pack__slug=pack)
     return present, 1 + len(POWER_BOOST_TABLE) + 1
 
 

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -1250,7 +1250,7 @@ SHARED_LASTING_RESULTS = {
 }
 
 
-def _lasting_row(model, name, qualifier, slot_type, defaults):
+def _table_row(model, name, qualifier, slot_type, defaults):
     """One pickable or slot for a table, matched three ways in turn.
 
     Its own slot type's row of that name is the one, whatever qualifier
@@ -1296,7 +1296,7 @@ def _create_lasting_effect_tables():
                 roll_selects="band",
             )
         for position, (low, high, result) in enumerate(rows):
-            pickable = _lasting_row(
+            pickable = _table_row(
                 Pickable, result, _twin_qualifier(index, result), slot_type, {}
             )
             PicklistMember.objects.get_or_create(
@@ -1308,7 +1308,7 @@ def _create_lasting_effect_tables():
                     "position": position,
                 },
             )
-        _lasting_row(
+        _table_row(
             Slot,
             name,
             "",
@@ -1324,7 +1324,7 @@ def _create_lasting_effect_tables():
             status = statuses.get(result)
             if status is not None:
                 _status_modifier(
-                    _lasting_row(
+                    _table_row(
                         Pickable, result, _twin_qualifier(index, result), slot_type, {}
                     ),
                     status,
@@ -1335,7 +1335,7 @@ def _create_lasting_effect_tables():
         for _, _, result in rows:
             if result in CAPTURED_RESULTS:
                 _grants_escape(
-                    _lasting_row(
+                    _table_row(
                         Pickable, result, _twin_qualifier(index, result), slot_type, {}
                     ),
                     escape,
@@ -1366,14 +1366,14 @@ def _create_escape_table():
             roll_selects="band",
         )
     for position, (low, high, result) in enumerate(ESCAPE_TABLE):
-        pickable = _lasting_row(Pickable, result, "", slot_type, {})
+        pickable = _table_row(Pickable, result, "", slot_type, {})
         PicklistMember.objects.get_or_create(
             picklist=table,
             pickable=pickable,
             defaults={"roll_low": low, "roll_high": high, "position": position},
         )
         _status_modifier(pickable, ESCAPE_STATUSES[result])
-    return _lasting_row(
+    return _table_row(
         Slot,
         ESCAPE_SLOT_TYPE,
         "",
@@ -1419,20 +1419,28 @@ POWER_BOOST_TABLE = [
 
 
 def _power_boost_result(slot_type, name, annotation, rating):
-    """One result, matched by name and annotation under its own slot
-    type; a name another slot type already claims is refused in words,
-    as the lasting tables do. The annotation doubles as the qualifier so
-    two results of one name are two rows under the per-pack constraint."""
+    """One result, matched by name and qualifier under its own slot type
+    in the default pack; a name another slot type there already claims
+    is refused in words, as the lasting tables do. The annotation doubles
+    as the qualifier so two results of one name are two rows under the
+    per-pack constraint, and the qualifier is what a re-run matches on:
+    an author may reword the annotation without the seed losing its row.
+    Pinned to the pack because names are unique per pack, so a homebrew
+    pack's result of the same name is a different thing.
+    """
+    from django.conf import settings
+
     from n26.library.models import Pickable
 
-    own = Pickable.objects.filter(
-        name__iexact=name, annotation__iexact=annotation, slot_type=slot_type
-    ).first()
+    in_pack = Pickable.objects.filter(
+        name__iexact=name,
+        qualifier__iexact=annotation,
+        pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+    )
+    own = in_pack.filter(slot_type=slot_type).first()
     if own is not None:
         return own
-    taken = Pickable.objects.filter(
-        name__iexact=name, qualifier__iexact=annotation
-    ).first()
+    taken = in_pack.first()
     if taken is not None:
         raise RuntimeError(
             f'A pickable named "{name}" already belongs to the '
@@ -1475,7 +1483,7 @@ def _create_power_boost_table():
             pickable=pickable,
             defaults={"roll_low": low, "roll_high": high, "position": position},
         )
-    _lasting_row(
+    _table_row(
         Slot,
         POWER_BOOST_SLOT_TYPE,
         "",

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -1261,10 +1261,17 @@ def _table_row(model, name, qualifier, slot_type, defaults):
     (lowercased name and qualifier, not slot type) as a bare error.
     Otherwise the row is created.
     """
-    own = model.objects.filter(name__iexact=name, slot_type=slot_type).first()
+    from django.conf import settings
+
+    # The default pack only: names are unique per pack, so a homebrew
+    # pack's row of the same name is neither this seed's nor in its way.
+    in_pack = model.objects.filter(
+        name__iexact=name, pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG
+    )
+    own = in_pack.filter(slot_type=slot_type).first()
     if own is not None:
         return own
-    taken = model.objects.filter(name__iexact=name, qualifier__iexact=qualifier).first()
+    taken = in_pack.filter(qualifier__iexact=qualifier).first()
     if taken is not None:
         raise RuntimeError(
             f'A {model._meta.verbose_name} named "{name}" already belongs '

--- a/n26/tests/sandbox/test_power_boost.py
+++ b/n26/tests/sandbox/test_power_boost.py
@@ -1,0 +1,406 @@
+"""Suit Evolution: a Spyrer spends Kill Count and rolls on the Power Boost
+table.
+
+The table is standard content, seeded the way the lasting-effect tables
+are: a slot type of its own, a D6 band table, a standing choice. What is
+new is that a result carries what it adds to the model's rating — the
+figure the book prints beside it — and the pick carries that rating
+without anything being paid.
+
+What an author finishes by hand, this file does with the verbs, as the
+cookbook says to: the four characteristic results get a modifier that
+improves the characteristic; every result gets one that moves the Kill
+Count down by four when the pick lands; and the Spyre Hunters gang type
+gives every Spyrer the choice. The choice is never narrowed by the count.
+A pick whose choice has gone is discarded as an orphan, so a choice that
+came and went with the Kill Count would take every boost already taken
+with it the moment the count fell below four. Inform, never police: the
+line is always there, and the count is the player's to read.
+"""
+
+import re
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.card import build_card, build_modifier_index
+from n26.core.effects import compute
+from n26.core.models import Assignment, LedgerEvent
+from n26.core.operations import operation
+from n26.core.reconcile import assert_reconciled
+from n26.core.render import build_model_card
+from n26.library.models import Picklist, Slot
+from n26.library.standard_content import POWER_BOOST_TABLE, STANDARD_CONTENT
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    changes_stat,
+    create_counter,
+    create_profile,
+    create_subtype,
+    ef_adds,
+    found_gang,
+    has_subtypes,
+    hire,
+    modifier,
+    op_changes_counter,
+    remove,
+    set_statline,
+    tally,
+    targets_every_model,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def boost(default_pack):
+    """The shipped table and its choice."""
+    STANDARD_CONTENT["power-boost-table"].create()
+    return {
+        "table": Picklist.objects.get(name="Power Boost Table"),
+        "slot": Slot.objects.get(name="Power Boost"),
+    }
+
+
+@pytest.fixture
+def kill_count(default_pack):
+    return create_counter("Kill Count")
+
+
+@pytest.fixture
+def spyrer_subtype(default_pack):
+    return create_subtype("Spyrer")
+
+
+def result_named(table, name, annotation=""):
+    return next(
+        m.pickable
+        for m in table.members.all()
+        if m.pickable.name == name and m.pickable.annotation == annotation
+    )
+
+
+@pytest.fixture
+def finished_results(boost, kill_count, fighter_stats):
+    """The cookbook's steps 3 and 4: what each result does, and the spend
+    every result carries."""
+    table = boost["table"]
+    raises = {
+        ("Combat Neuroware", "WS"): "WS",
+        ("Combat Neuroware", "BS"): "BS",
+        ("Heightened Reactions", ""): "I",
+        ("Improved Motive Power", ""): "M",
+        ("Thickened Armour", ""): "Sv",
+    }
+    for member in table.members.all():
+        result = member.pickable
+        stat = raises.get((result.name, result.annotation))
+        if stat is not None:
+            modifier(
+                f"{result}: raises {stat}",
+                targets_model(),
+                changes_stat(fighter_stats[stat], mode="improve", amount=1),
+                carried_by=result,
+            )
+        modifier(
+            f"{result}: spends four Kill Count",
+            targets_model(),
+            op_changes_counter(kill_count, mode="subtract", amount=4),
+            carried_by=result,
+        )
+    return table
+
+
+@pytest.fixture
+def gang(gang_type, owner, boost, spyrer_subtype, finished_results):
+    """Step 5: the gang type gives every Spyrer the choice, narrowed by
+    the subtype and never by the Kill Count."""
+    modifier(
+        "Spyrers carry Power Boost",
+        targets_every_model(has_subtypes(spyrer_subtype)),
+        ef_adds(boost["slot"]),
+        carried_by=gang_type,
+    )
+    return found_gang("The Descent", gang_type, owner=owner, budget=2000)
+
+
+@pytest.fixture
+def spyrer(fighter_type, gang_type, spyrer_subtype, kill_count):
+    profile = create_profile("Orrus Spyre Hunter", fighter_type, gang_type, price=300)
+    set_statline(
+        profile,
+        movement=5,
+        weapon_skill=4,
+        ballistic_skill=3,
+        strength=4,
+        toughness=4,
+        wounds=2,
+        initiative=4,
+        attacks=2,
+        save=4,
+        leadership=6,
+        cool=6,
+        willpower=6,
+        intelligence=6,
+    )
+    add_built_in(profile, spyrer_subtype)
+    add_built_in(profile, kill_count, amount=0)
+    return profile
+
+
+@pytest.fixture
+def orrus(gang, spyrer):
+    """Hired, and six kills in."""
+    model = hire(gang, spyrer, "Orrus", paid=300)
+    tally(kill_row(model), +6)
+    return model
+
+
+def kill_row(miniature):
+    return Assignment.objects.get(miniature=miniature, counter__name="Kill Count")
+
+
+def kills_of(miniature):
+    return kill_row(miniature).counter_value.value
+
+
+def card_for(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    computed = compute(card, index)
+    return build_model_card(miniature, card=card, computed=computed), computed
+
+
+def stat_of(miniature, short_name):
+    drawn, _ = card_for(miniature)
+    return drawn.statline.get(short_name).value
+
+
+def choice_of(miniature, label="Power Boost"):
+    _, computed = card_for(miniature)
+    return next((c for c in computed.choices if c.kind_label == label), None)
+
+
+def roll_for(miniature, rolled):
+    """A roll made at the table and entered — the number is the test's."""
+    choice = choice_of(miniature)
+    gang = miniature.membership.gang
+    with operation(gang, actor=gang.owner) as op:
+        return op.roll(choice.slot, miniature=miniature, rolled=rolled)
+
+
+def take(miniature, result, roll=None):
+    choice = choice_of(miniature)
+    gang = miniature.membership.gang
+    with operation(gang, actor=gang.owner) as op:
+        return op.choose(
+            choice.anchor.assignment,
+            result,
+            slot=choice.slot,
+            miniature=miniature,
+            roll=roll,
+        )
+
+
+class TestTheTableIsStandardContent:
+    """One click on Foundations, and the table stands as the book prints
+    it: six results, two of them on the first band, each carrying what it
+    adds to the model's rating."""
+
+    def test_the_results_and_their_ratings_are_pinned(self, boost):
+        rows = [
+            (m.roll_low, m.roll_high, m.pickable.name, m.pickable.annotation)
+            for m in boost["table"].members.order_by("position")
+        ]
+        assert rows == [
+            (low, high, name, note) for low, high, name, note, _ in POWER_BOOST_TABLE
+        ]
+        assert [
+            m.pickable.rating_contribution
+            for m in boost["table"].members.order_by("position")
+        ] == [rating for *_, rating in POWER_BOOST_TABLE]
+
+    def test_a_one_lands_on_both_neuroware_results(self, boost):
+        assert [str(m.pickable) for m in boost["table"].landing(1)] == [
+            "Combat Neuroware (WS)",
+            "Combat Neuroware (BS)",
+        ]
+
+    def test_every_other_roll_lands_on_one(self, boost):
+        for roll in (2, 3, 4, 5, 6):
+            assert len(boost["table"].landing(roll)) == 1
+
+    def test_the_choice_repeats_across_a_campaign(self, boost):
+        slot = boost["slot"]
+        assert (slot.min_picks, slot.max_picks) == (0, 20)
+        assert slot.slot_type.allows_repeats
+
+
+class TestSpendingKillCount:
+    """A result picked is four Kill Count gone, a characteristic raised
+    where the result says, and the model worth more by the printed figure
+    — with nothing paid, so nothing to refund."""
+
+    def test_the_spyrer_carries_the_choice_and_a_ganger_does_not(
+        self, gang, orrus, fighter_type, gang_type
+    ):
+        ganger = hire(
+            gang,
+            create_profile("Ganger", fighter_type, gang_type, price=50),
+            "Krago",
+            paid=50,
+        )
+
+        assert choice_of(orrus) is not None
+        assert choice_of(ganger) is None
+        assert_reconciled(gang)
+
+    def test_neuroware_raises_weapon_skill_and_spends_four(self, gang, orrus, boost):
+        gang.refresh_from_db()
+        rating_before = gang.rating
+        assert stat_of(orrus, "WS") == "4+"
+
+        roll = roll_for(orrus, 1)
+        pick = take(
+            orrus, result_named(boost["table"], "Combat Neuroware", "WS"), roll=roll
+        )
+
+        assert stat_of(orrus, "WS") == "3+"
+        assert stat_of(orrus, "BS") == "3+"
+        assert kills_of(orrus) == 2
+        orrus.refresh_from_db()
+        gang.refresh_from_db()
+        assert orrus.rating == 320
+        assert gang.rating == rating_before + 20
+        entry = pick.ledger_entry
+        assert (entry.paid, entry.rating_contribution) == (0, 20)
+        assert_reconciled(gang)
+
+    def test_each_result_raises_its_own_characteristic(self, gang, orrus, boost):
+        table = boost["table"]
+        before = {short: stat_of(orrus, short) for short in ("I", "M", "Sv")}
+        assert before == {"I": "4", "M": '5"', "Sv": "4+"}
+
+        take(orrus, result_named(table, "Heightened Reactions"))
+        take(orrus, result_named(table, "Improved Motive Power"))
+        take(orrus, result_named(table, "Thickened Armour"))
+
+        assert stat_of(orrus, "I") == "5"
+        assert stat_of(orrus, "M") == '6"'
+        assert stat_of(orrus, "Sv") == "3+"
+        orrus.refresh_from_db()
+        assert orrus.rating == 300 + 10 + 10 + 15
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_augmentation_changes_no_number_but_counts_twenty(self, gang, orrus, boost):
+        before = {s: stat_of(orrus, s) for s in ("WS", "BS", "I", "M", "Sv")}
+
+        roll = roll_for(orrus, 6)
+        take(orrus, result_named(boost["table"], "Hunting Rig Augmentation"), roll=roll)
+
+        assert {s: stat_of(orrus, s) for s in ("WS", "BS", "I", "M", "Sv")} == before
+        assert kills_of(orrus) == 2
+        orrus.refresh_from_db()
+        assert orrus.rating == 320
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_capped_result_is_substituted_by_the_player(self, gang, orrus, boost):
+        """The rules read a characteristic already at its best as Hunting
+        Rig Augmentation. The roll does not decide the pick, so the player
+        takes that result against a roll of one."""
+        roll = roll_for(orrus, 1)
+        pick = take(
+            orrus, result_named(boost["table"], "Hunting Rig Augmentation"), roll=roll
+        )
+
+        assert pick.roll == roll
+        assert stat_of(orrus, "WS") == "4+"
+        assert kills_of(orrus) == 2
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_the_choice_stays_when_the_count_falls_below_four(self, gang, orrus, boost):
+        """Nothing gates the line on the count. Below four it is still
+        there, and so is everything already picked for it."""
+        take(orrus, result_named(boost["table"], "Thickened Armour"))
+        assert kills_of(orrus) == 2
+
+        choice = choice_of(orrus)
+        assert choice is not None
+        assert [node.name for node in choice.picks] == ["Thickened Armour"]
+        assert stat_of(orrus, "Sv") == "3+"
+
+        take(orrus, result_named(boost["table"], "Heightened Reactions"))
+        assert kills_of(orrus) == 0
+        assert len(choice_of(orrus).picks) == 2
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_taking_a_result_back_drops_its_rating_and_keeps_the_spend(
+        self, gang, orrus, boost
+    ):
+        """The four Kill Count were spent when the pick landed; taking the
+        result back is a removal, and a removal moves no counter and no
+        credits. The rating stops counting because the pick is archived."""
+        pick = take(orrus, result_named(boost["table"], "Thickened Armour"))
+        gang.refresh_from_db()
+        credits_before = gang.credits
+
+        remove(pick)
+
+        assert kills_of(orrus) == 2
+        assert stat_of(orrus, "Sv") == "4+"
+        orrus.refresh_from_db()
+        gang.refresh_from_db()
+        assert orrus.rating == 300
+        assert gang.credits == credits_before
+        assert_reconciled(gang)
+
+
+class TestThePickScreen:
+    """The page the player rolls on: a one lifts both Combat Neuroware
+    rows and offers each, so the choice of Weapon Skill or Ballistic
+    Skill needs no machinery of its own."""
+
+    @pytest.fixture
+    def address(self, gang, orrus):
+        choice = choice_of(orrus)
+        key = f"{orrus.pk}:{choice.anchor.assignment.pk}:{choice.identity.pk}"
+        return reverse("n26-choose", args=[gang.pk, key])
+
+    def test_a_one_lifts_both_neuroware_rows(self, client, owner, address):
+        client.force_login(owner)
+        client.post(address, {"act": "enter", "rolled": "1"})
+        event = LedgerEvent.objects.get(kind=LedgerEvent.Kind.ROLLED)
+
+        page = client.get(f"{address}?roll={event.pk}").content.decode()
+
+        assert "Rolled 1" in page
+        assert re.search(
+            r"Landed on <strong[^>]*>Combat Neuroware \(WS\)</strong>, "
+            r"<strong[^>]*>Combat Neuroware \(BS\)</strong>\.",
+            page,
+        )
+        assert 'aria-label="Add Combat Neuroware (WS)"' in page
+        assert 'aria-label="Add Combat Neuroware (BS)"' in page
+
+    def test_a_six_lifts_the_augmentation(self, client, owner, address):
+        client.force_login(owner)
+        client.post(address, {"act": "enter", "rolled": "6"})
+        event = LedgerEvent.objects.get(kind=LedgerEvent.Kind.ROLLED)
+
+        page = client.get(f"{address}?roll={event.pk}").content.decode()
+
+        assert re.search(
+            r"Landed on <strong[^>]*>Hunting Rig Augmentation</strong>\.", page
+        )
+        assert 'aria-label="Add Hunting Rig Augmentation"' in page

--- a/n26/tests/sandbox/test_power_boost.py
+++ b/n26/tests/sandbox/test_power_boost.py
@@ -2,10 +2,10 @@
 table.
 
 The table is standard content, seeded the way the lasting-effect tables
-are: a slot type of its own, a D6 band table, a standing choice. What is
-new is that a result carries what it adds to the model's rating — the
-figure the book prints beside it — and the pick carries that rating
-without anything being paid.
+are: a slot type of its own, a D6 band table, a standing choice. Each
+result carries what it adds to the model's rating — the figure the book
+prints beside it — and the pick carries that rating without anything
+being paid.
 
 What an author finishes by hand, this file does with the verbs, as the
 cookbook says to: the four characteristic results get a modifier that
@@ -89,8 +89,8 @@ def result_named(table, name, annotation=""):
 
 @pytest.fixture
 def finished_results(boost, kill_count, fighter_stats):
-    """The cookbook's steps 3 and 4: what each result does, and the spend
-    every result carries."""
+    """What an author attaches by hand: what each result does, and the
+    spend every result carries."""
     table = boost["table"]
     raises = {
         ("Combat Neuroware", "WS"): "WS",
@@ -120,8 +120,8 @@ def finished_results(boost, kill_count, fighter_stats):
 
 @pytest.fixture
 def gang(gang_type, owner, boost, spyrer_subtype, finished_results):
-    """Step 5: the gang type gives every Spyrer the choice, narrowed by
-    the subtype and never by the Kill Count."""
+    """The gang type gives every Spyrer the choice, narrowed by the
+    subtype and never by the Kill Count."""
     modifier(
         "Spyrers carry Power Boost",
         targets_every_model(has_subtypes(spyrer_subtype)),
@@ -215,17 +215,60 @@ class TestTheTableIsStandardContent:
     adds to the model's rating."""
 
     def test_the_results_and_their_ratings_are_pinned(self, boost):
+        """Pinned as literals, so the seed changes deliberately."""
         rows = [
-            (m.roll_low, m.roll_high, m.pickable.name, m.pickable.annotation)
+            (
+                m.roll_low,
+                m.roll_high,
+                str(m.pickable),
+                m.pickable.qualifier,
+                m.pickable.rating_contribution,
+            )
             for m in boost["table"].members.order_by("position")
         ]
         assert rows == [
-            (low, high, name, note) for low, high, name, note, _ in POWER_BOOST_TABLE
+            (1, 1, "Combat Neuroware (WS)", "WS", 20),
+            (1, 1, "Combat Neuroware (BS)", "BS", 20),
+            (2, 2, "Heightened Reactions", "", 10),
+            (3, 3, "Improved Motive Power", "", 10),
+            (4, 4, "Thickened Armour", "", 15),
+            (5, 6, "Hunting Rig Augmentation", "", 20),
         ]
-        assert [
-            m.pickable.rating_contribution
-            for m in boost["table"].members.order_by("position")
-        ] == [rating for *_, rating in POWER_BOOST_TABLE]
+        assert len(rows) == len(POWER_BOOST_TABLE)
+
+    def test_a_reworded_annotation_keeps_its_row_on_a_second_click(self, boost):
+        """An author may reword what a result prints. The seed matches its
+        rows by qualifier, so a second click adopts the reworded row
+        rather than refusing or creating a twin."""
+        from n26.library.models import Pickable
+
+        ws = Pickable.objects.get(name="Combat Neuroware", qualifier="WS")
+        ws.annotation = "Weapon Skill"
+        ws.save()
+
+        STANDARD_CONTENT["power-boost-table"].create()
+
+        assert Pickable.objects.filter(name="Combat Neuroware").count() == 2
+        assert boost["table"].members.count() == 6
+        assert STANDARD_CONTENT["power-boost-table"].status() == "complete"
+
+    def test_a_homebrew_result_of_the_same_name_is_not_in_the_way(
+        self, boost, homebrew
+    ):
+        """Names are unique per pack. A homebrew pack's own Thickened
+        Armour is a different thing, and the Foundations click must not
+        refuse over it."""
+        from n26.library.models import Pickable, SlotType
+
+        Pickable.objects.create(
+            name="Thickened Armour",
+            slot_type=SlotType.objects.get(name="Power Boost"),
+            pack=homebrew,
+        )
+
+        STANDARD_CONTENT["power-boost-table"].create()
+
+        assert boost["table"].members.count() == 6
 
     def test_a_one_lands_on_both_neuroware_results(self, boost):
         assert [str(m.pickable) for m in boost["table"].landing(1)] == [

--- a/n26/tests/sandbox/test_power_boost.py
+++ b/n26/tests/sandbox/test_power_boost.py
@@ -371,6 +371,29 @@ class TestSpendingKillCount:
         gang.refresh_from_db()
         assert_reconciled(gang)
 
+    def test_a_characteristic_at_its_best_stays_there(
+        self, gang, spyrer, boost, fighter_stats
+    ):
+        """Weapon Skill stops at 2+. A Spyrer already there who takes
+        Combat Neuroware anyway is not refused — the app informs — and
+        the characteristic reads 2+ still; the rules say such a result
+        counts as Hunting Rig Augmentation, which is the player's to pick
+        instead, and either way the rating rises by twenty."""
+        set_statline(spyrer, weapon_skill=2)
+        ace = hire(gang, spyrer, "Ace", paid=300)
+        tally(kill_row(ace), +4)
+        assert stat_of(ace, "WS") == "2+"
+
+        roll = roll_for(ace, 1)
+        take(ace, result_named(boost["table"], "Combat Neuroware", "WS"), roll=roll)
+
+        assert stat_of(ace, "WS") == "2+"
+        assert kills_of(ace) == 0
+        ace.refresh_from_db()
+        assert ace.rating == 320
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
     def test_the_choice_stays_when_the_count_falls_below_four(self, gang, orrus, boost):
         """Nothing gates the line on the count. Below four it is still
         there, and so is everything already picked for it."""


### PR DESCRIPTION
## Summary

- **The Power Boost table is standard content.** A new Foundations item, `power-boost-table`, creates the Spyre Hunting Party's Power Boost roll table the way the lasting-effect tables are created: a slot type with repeats allowed, a D6 band table, a standing choice of up to twenty picks. Each result carries the credits it adds to the model's rating (20, 20, 10, 10, 15, 20) as its `rating_contribution`, so a pick raises the Spyrer's value with nothing paid. The first band holds two results, Combat Neuroware (WS) and Combat Neuroware (BS), told apart by annotation, so the book's "raise WS or BS" needs no choice machinery: a roll of one lifts both on the pick screen.
- **What authors finish by hand is written into the cookbook.** Following the lasting-tables doctrine (names and numbers only), a new "Suit Evolution" section in `n26/library/recipes.md` gives the steps: a Kill Count counter built into Spyrer entries, a modifier on each characteristic result, a stored "moves the Kill Count down by four" on every result, and a gang-type modifier that gives Spyrers the choice. It says in words why the choice must never be narrowed by the Kill Count: a choice that comes and goes with the count would take every result already picked with it.
- **The whole flow is proven end to end** in `n26/tests/sandbox/test_power_boost.py`, which performs those authoring steps with the verbs: a one offers both Neuroware rows on the page, a pick raises the characteristic, spends four Kill Count and adds the printed figure to the model's and gang's rating with `paid=0`; a capped result is substituted by the player against the roll; the choice and its picks survive the count dropping below four; taking a result back drops its rating and does not give the four back.

Third PR of the Spyrer suit evolution plan (`.claude/notes/issue-2313-plan.md`), after #2500 and #2514. No migration, no code outside the seed. Nothing changes for existing gangs until an author clicks the Foundations item and follows the recipe.

## Test plan

- [x] `pytest -n 4 n26` — 6142 passed, 1 xfailed (before the two page tests; 13/13 in the new file after)
- [x] `test_foundations.py` guards cover the new key: missing on an empty library, complete after one click, unchanged after a second
- [x] `test_power_boost.py`: table pinned to the book's bands and ratings; both Neuroware rows land on a one; page lifts both; spend, raise, rating; substitution; no gating; removal semantics
- [ ] Manual: Foundations page shows "Power Boost table"; one click creates it; the slot type page lists six results with two on band 1

Refs #2313
Refs #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
