### PR TITLE
fix: the category form offers the own-row switch

### DIFF
--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -1664,17 +1664,27 @@ def create_section(name, position=0, **kwargs):
     return Section.objects.create(name=name, position=position, **kwargs)
 
 
-def create_category(section, name, position=0, **kwargs):
+def create_category(section, name, position=0, draws_its_own_row=False, **kwargs):
     """A category under its heading. ``section`` is a Section row, or a
     name — named headings are found or founded, so the example suites
-    keep reading ``create_category("Skills", "Combat")``."""
+    keep reading ``create_category("Skills", "Combat")``.
+
+    ``draws_its_own_row`` puts the category's items under their own
+    heading on a model's card rather than in with the rest of the gear.
+    A named parameter rather than a pass-through, because the authoring
+    form reads a switch's starting state off this signature.
+    """
     from n26.library.models import Category, Section
 
     if not isinstance(section, Section):
         shared = {"pack": kwargs["pack"]} if "pack" in kwargs else {}
         section, _ = Section.objects.get_or_create(name=section, **shared)
     return Category.objects.create(
-        section=section, name=name, position=position, **kwargs
+        section=section,
+        name=name,
+        position=position,
+        draws_its_own_row=draws_its_own_row,
+        **kwargs,
     )
 
 

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -1672,7 +1672,9 @@ def create_category(section, name, position=0, draws_its_own_row=False, **kwargs
     ``draws_its_own_row`` puts the category's items under their own
     heading on a model's card rather than in with the rest of the gear.
     A named parameter rather than a pass-through, because the authoring
-    form reads a switch's starting state off this signature.
+    form reads a switch off this signature — its starting state, and
+    whether it must be filled — and a name the catch-all absorbs is not
+    there to read.
     """
     from n26.library.models import Category, Section
 

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -308,7 +308,7 @@ its modifiers.
 
 *Where an item always sorts: one named home inside a section.*
 
-Fields: its Section, a name, a position.
+Fields: its Section, a name, a position, and whether its items draw under their own heading on a model's card rather than in with the rest of the gear.
 
 Used as a home for an *item* in a collection, so every collection groups it the same way — an autogun is an Auto/Stub Weapon everywhere. The same name may recur under different sections (Primitive Weapons under both Ranged and Close Combat).
 

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -1153,6 +1153,7 @@ def _build_registry():
                 "section": One(model=Section, source=(Category, "section")),
                 "name": Text(source=(Category, "name")),
                 "position": Int(source=(Category, "position")),
+                "draws_its_own_row": Bool(source=(Category, "draws_its_own_row")),
             },
         ),
         # The gang surface: the type, the entries hired off its list,

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -724,6 +724,46 @@ class TestSections:
         assert made.section == heading
         assert str(made) == "Ranged Weapons: Auto/Stub Weapons"
 
+    def test_a_category_can_be_told_to_draw_its_own_row(
+        self, author, client, default_pack
+    ):
+        """Whether a category's items draw under their own heading on a
+        card is an authoring decision, so it has to be on the authoring
+        form — on the page that makes a category and the one that changes
+        it, since the same form serves both."""
+        from n26.library.authoring import create_category
+        from n26.library.models import Category
+
+        home = create_category("Wargear", "Gene-smithing")
+        assert not home.draws_its_own_row
+
+        body = client.get(f"/n26/authoring/category/{home.pk}/").content.decode()
+        assert 'name="edit-draws_its_own_row"' in body
+
+        client.post(
+            f"/n26/authoring/category/{home.pk}/",
+            {
+                "act": "edit",
+                "edit-section": str(home.section.pk),
+                "edit-name": "Gene-smithing",
+                "edit-position": "0",
+                "edit-draws_its_own_row": "on",
+            },
+        )
+        home.refresh_from_db()
+        assert home.draws_its_own_row
+
+        client.post(
+            "/n26/authoring/category/new/",
+            {
+                "name": "Chem-alchemy Elixirs",
+                "section": str(home.section.pk),
+                "position": "1",
+                "draws_its_own_row": "on",
+            },
+        )
+        assert Category.objects.get(name="Chem-alchemy Elixirs").draws_its_own_row
+
     def test_named_headings_are_founded_once(self, default_pack):
         """The example suites still say create_category("Skills", …) —
         the heading is found or founded, never forked."""

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -737,21 +737,32 @@ class TestSections:
         home = create_category("Wargear", "Gene-smithing")
         assert not home.draws_its_own_row
 
-        body = client.get(f"/n26/authoring/category/{home.pk}/").content.decode()
+        page = f"/n26/authoring/category/{home.pk}/"
+        body = client.get(page).content.decode()
         assert 'name="edit-draws_its_own_row"' in body
+        assert "switchInput(false, true)" not in body  # drawn off, as stored
 
-        client.post(
-            f"/n26/authoring/category/{home.pk}/",
-            {
-                "act": "edit",
-                "edit-section": str(home.section.pk),
-                "edit-name": "Gene-smithing",
-                "edit-position": "0",
-                "edit-draws_its_own_row": "on",
-            },
-        )
+        edit = {
+            "act": "edit",
+            "edit-section": str(home.section.pk),
+            "edit-name": "Gene-smithing",
+            "edit-position": "0",
+        }
+        client.post(page, {**edit, "edit-draws_its_own_row": "on"})
         home.refresh_from_db()
         assert home.draws_its_own_row
+
+        # Reopened, the switch shows the value it has. Without this an
+        # author saving an unrelated change would clear the flag and
+        # never know.
+        body = client.get(page).content.decode()
+        assert "switchInput(false, true)" in body
+
+        # Unticking is the direction that loses an author's work, so it
+        # is held as well as ticking: an absent box on an edit means off.
+        client.post(page, edit)
+        home.refresh_from_db()
+        assert not home.draws_its_own_row
 
         client.post(
             "/n26/authoring/category/new/",


### PR DESCRIPTION
The own-row switch on a category (#2501) arrived on the model without arriving on the authoring page. This library's forms are generated from specs, and the category spec listed section, name and position only — so nobody could tick **Its own row on a card** from the page that makes a category or the page that changes it, and the feature was unreachable to an author.

One line in the spec puts it on both pages, since the same spec serves create and edit. The verb gains the parameter by name too, because the form reads a switch's starting state off the verb's signature and a catch-all has none to read.

A test opens a category's edit page, asserts the switch is drawn, ticks it and reads it back, then makes a new category with it ticked.

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
