### PR TITLE
feat: a firing line's delete page removes a free line from the fighters that have it before deleting the row

### DIFF
--- a/n26/library/deletion.py
+++ b/n26/library/deletion.py
@@ -26,6 +26,15 @@ reader, and sorts each into one of three:
   that stays). The author edits those first: content that has been used
   is history, and content something else names is a decision.
 
+A firing line has one more ending, asked for with ``remove_free_lines``.
+A weapon's free lines ride along with it onto every fighter that has the
+weapon: nobody chose them and nobody paid. Deleting such a line is not
+taking history away from anyone, it is reversing a grant the content
+made, so the plan names the fighters that have it and the line is
+removed from each, gang by gang, before the row goes
+(:func:`remove_free_lines_from`). A line somebody paid for, or one with
+something under it, refuses as any held row does.
+
 The plan is the contract. The page draws it, and :func:`apply` reads it
 again under locks and performs exactly it, or refuses because what stood
 has changed since it was read. Nothing here writes outside ``apply``.
@@ -91,6 +100,41 @@ class Holder:
 
 
 @dataclass(frozen=True)
+class Line:
+    """The fighters on one gang that have a free firing line."""
+
+    pk: str
+    name: str
+    owner: str
+    archived: bool
+    #: The fighters' names, one per line held.
+    fighters: tuple = ()
+    #: The assignments that are the lines, one per fighter.
+    assignment_ids: tuple = ()
+
+    def as_dict(self):
+        return {
+            "pk": str(self.pk),
+            "name": self.name,
+            "owner": self.owner,
+            "archived": self.archived,
+            "fighters": list(self.fighters),
+            "assignment_ids": [str(pk) for pk in self.assignment_ids],
+        }
+
+    @classmethod
+    def from_dict(cls, held):
+        return cls(
+            pk=held["pk"],
+            name=held["name"],
+            owner=held["owner"],
+            archived=bool(held.get("archived")),
+            fighters=tuple(held.get("fighters", ())),
+            assignment_ids=tuple(held.get("assignment_ids", ())),
+        )
+
+
+@dataclass(frozen=True)
 class DeletionPlan:
     """What deleting the rows asked for would take, and what stops it."""
 
@@ -108,6 +152,9 @@ class DeletionPlan:
     modifier_ids: tuple = ()
     gangs: tuple = ()
     campaigns: tuple = ()
+    #: Gangs whose fighters have a free firing line that is going, and
+    #: from which it is removed first.
+    lines: tuple = ()
     refusals: tuple = ()
     nothing_here: bool = False
 
@@ -117,9 +164,14 @@ class DeletionPlan:
 
     @property
     def touches_players(self):
-        """Whether the act deletes any gang or campaign, and so belongs
-        on the recorded task runner rather than in a request."""
-        return bool(self.gangs or self.campaigns)
+        """Whether the act changes any gang — deleting one, or removing
+        a line from its fighters — and so belongs on the recorded task
+        runner rather than in a request."""
+        return bool(self.gangs or self.campaigns or self.lines)
+
+    @property
+    def fighters_with_lines(self):
+        return sum(len(line.fighters) for line in self.lines)
 
     @property
     def test_gangs(self):
@@ -170,6 +222,15 @@ class DeletionPlan:
                 f"which holds {_and(campaign.holds)}, with its own campaign "
                 "type and pack"
             )
+        if self.lines:
+            fighters = self.fighters_with_lines
+            gangs = len(self.lines)
+            lines.append(
+                f"remove the firing line from {fighters} "
+                f"fighter{'' if fighters == 1 else 's'} on {gangs} "
+                f"gang{'' if gangs == 1 else 's'} first: nobody paid for it, "
+                "the weapon brought it"
+            )
         for refusal in self.refusals:
             lines.append(f"refused: {refusal}")
         return lines
@@ -182,6 +243,7 @@ class DeletionPlan:
             "rows": [[label, str(pk), said] for label, pk, said in self.rows],
             "gangs": [gang.as_dict() for gang in self.gangs],
             "campaigns": [campaign.as_dict() for campaign in self.campaigns],
+            "lines": [line.as_dict() for line in self.lines],
             "refusals": list(self.refusals),
             "preview": list(self.preview()),
         }
@@ -198,6 +260,7 @@ class DeletionPlan:
             ),
             gangs=tuple(Holder.from_dict(h) for h in summary.get("gangs", [])),
             campaigns=tuple(Holder.from_dict(h) for h in summary.get("campaigns", [])),
+            lines=tuple(Line.from_dict(line) for line in summary.get("lines", [])),
             refusals=tuple(summary.get("refusals", [])),
             nothing_here=not summary.get("targets"),
         )
@@ -212,6 +275,8 @@ class DeletionPlan:
             == {str(gang.pk) for gang in other.test_gangs}
             and {str(campaign.pk) for campaign in self.test_campaigns}
             == {str(campaign.pk) for campaign in other.test_campaigns}
+            and {str(pk) for line in self.lines for pk in line.assignment_ids}
+            == {str(pk) for line in other.lines for pk in line.assignment_ids}
             and self.refusals == other.refusals
         )
 
@@ -273,12 +338,14 @@ class _Planner:
     """One reading. Everything doomed is queued, its references read
     and sorted, and anything those bring down queued in turn."""
 
-    def __init__(self, things):
+    def __init__(self, things, remove_free_lines=False):
         self.targets = [thing for thing in things]
+        self.remove_free_lines = remove_free_lines
         self.doomed = {}
         self.roots = []
         self.modifiers = {}
         self.holders = {}
+        self.lines = {}
         self.refusals = []
         self.queue = []
 
@@ -322,6 +389,24 @@ class _Planner:
         if holds not in holder.holds:
             holder = replace(holder, holds=(*holder.holds, holds))
         self.holders[key] = holder
+
+    def line(self, gang, assignment):
+        """One fighter's free firing line, to be removed before the row goes."""
+        key = str(gang.pk)
+        held = self.lines.get(key)
+        if held is None:
+            held = Line(
+                pk=key,
+                name=gang.name,
+                owner=gang.owner.username if gang.owner_id else "",
+                archived=gang.archived,
+            )
+        fighter = assignment.miniature_root.name if assignment.miniature_root_id else ""
+        self.lines[key] = replace(
+            held,
+            fighters=(*held.fighters, fighter),
+            assignment_ids=(*held.assignment_ids, str(assignment.pk)),
+        )
 
     def refuse(self, words):
         if words not in self.refusals:
@@ -459,6 +544,24 @@ class _Planner:
         gang = campaign = None
         if label == "n26.assignment":
             gang = self.gang_of_assignment(row)
+            if (
+                self.remove_free_lines
+                and reference.field == "weapon_profile"
+                and gang is not None
+            ):
+                why_not = _why_not_a_free_line(row)
+                if not why_not:
+                    self.line(gang, row)
+                    return
+                fighter = (
+                    row.miniature_root.name if row.miniature_root_id else "a fighter"
+                )
+                self.refuse(
+                    f"“{gang.name}” ({gang.owner.username if gang.owner_id else ''}) "
+                    f"has {what} on {fighter} and {why_not}; refund or remove "
+                    "it first"
+                )
+                return
         elif label == "n26.gang":
             gang = row
         elif label == "n26.campaign":
@@ -572,6 +675,9 @@ class _Planner:
             modifier_ids=tuple(pk for _, pk in self.modifiers),
             gangs=tuple(sorted(gangs, key=lambda h: (h.owner, h.name))),
             campaigns=tuple(sorted(campaigns, key=lambda h: (h.owner, h.name))),
+            lines=tuple(
+                sorted(self.lines.values(), key=lambda line: (line.owner, line.name))
+            ),
             refusals=tuple(self.refusals),
             nothing_here=not self.targets,
         )
@@ -623,9 +729,54 @@ def _why_not_a_test_gang(gang):
     return ""
 
 
-def plan_deletion(things):
-    """Read what deleting these rows would take. Never writes."""
-    planner = _Planner(list(things))
+def _why_not_a_free_line(assignment):
+    """Why a firing line on a fighter is not one the weapon merely
+    brought — or empty where it is.
+
+    A free line sits under its weapon's own assignment, its books say
+    nothing was paid and nothing counts, and nothing hangs off it. Any
+    of those failing means somebody chose or paid for it, and it is
+    history.
+    """
+    from n26.core.models import Assignment
+
+    if assignment.parent_id is None:
+        return "is not under a weapon"
+    try:
+        entry = assignment.ledger_entry
+    except Assignment.ledger_entry.RelatedObjectDoesNotExist:
+        return "has no ledger entry"
+    if (
+        entry.list_price,
+        entry.discount,
+        entry.paid,
+        entry.trade_points,
+        entry.rating_contribution,
+    ) != (0, 0, 0, 0, 0):
+        return "was paid for"
+    if any(
+        (event.credits_delta, event.trade_points_delta, event.rating_delta) != (0, 0, 0)
+        for event in assignment.ledger_events.all()
+    ):
+        return "has moved money"
+    if (
+        assignment.children.exists()
+        or assignment.caused.exists()
+        or assignment.picks.exists()
+        or assignment.chosen_options.exists()
+        or Assignment.objects.filter(materialised_for=assignment).exists()
+    ):
+        return "has something under it"
+    return ""
+
+
+def plan_deletion(things, *, remove_free_lines=False):
+    """Read what deleting these rows would take. Never writes.
+
+    ``remove_free_lines`` asks for a firing line's fourth ending: the
+    free lines fighters have are named for removal rather than refusing.
+    """
+    planner = _Planner(list(things), remove_free_lines=remove_free_lines)
     planner.read()
     return planner.plan()
 
@@ -640,7 +791,107 @@ def plan_again(plan):
         if row is None:
             raise Refused(f"nothing was deleted: {label} {pk} is already gone")
         things.append(row)
-    return plan_deletion(things)
+    return plan_deletion(things, remove_free_lines=bool(plan.lines))
+
+
+class FreeLineRemoval:
+    """A plan with lines, as the gang-by-gang runner reads one: the gangs
+    to visit, the problems that refuse the whole run, and the preview."""
+
+    def __init__(self, plan):
+        self.plan = plan
+
+    @property
+    def gangs(self):
+        return [(line.pk,) for line in self.plan.lines]
+
+    @property
+    def problems(self):
+        return list(self.plan.refusals)
+
+    @property
+    def nothing_here(self):
+        return not self.plan.lines
+
+    def preview(self):
+        return list(self.plan.preview())
+
+
+def free_line_removal(plan):
+    """Read the plan again, under the runner's lock, for the walk.
+
+    What stood when the page was read is what the author confirmed. A
+    gang that gained or paid for the line since refuses the whole run in
+    words rather than being walked past.
+    """
+    now = plan_again(plan)
+    if not now.same_as(plan):
+        return FreeLineRemoval(
+            replace(
+                now,
+                refusals=(
+                    *now.refusals,
+                    "what holds this line has changed since the page was "
+                    "read — read it again",
+                ),
+            )
+        )
+    return FreeLineRemoval(now)
+
+
+def remove_free_lines_from(gang_id, plan):
+    """Take the plan's firing line off one gang's fighters, committed on
+    its own, and delete the row once no fighter anywhere has it.
+
+    The line is read again under the gang's lock — deliveries may be
+    minutes apart — and a fighter who has since paid for it, or whose
+    line has something under it, leaves the gang alone and named. The
+    assignments go with their zero-value entries and events, and the
+    gang is proved to reconcile before and after. The last gang visited
+    finds nothing else naming the row and deletes it.
+    """
+    from django.apps import apps
+
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import check_gang
+    from n26.library import authoring
+
+    with transaction.atomic():
+        gang = Gang.objects.select_for_update().get(pk=gang_id)
+        now = plan_again(plan)
+        if now.refusals:
+            return f"gang {gang.name}: skipped — " + "; ".join(now.refusals)
+        mine = [line for line in now.lines if str(line.pk) == str(gang.pk)]
+        if not mine:
+            return f"gang {gang.name}: nothing left to remove"
+        ids = [pk for pk in mine[0].assignment_ids]
+        list(Assignment.objects.select_for_update().filter(pk__in=ids).order_by("pk"))
+        problems = check_gang(gang)
+        if problems:
+            return (
+                f"gang {gang.name}: skipped — it did not reconcile before the "
+                "removal: " + "; ".join(problems)
+            )
+        Assignment.objects.filter(pk__in=ids).delete()
+        problems = check_gang(gang)
+        if problems:
+            raise Refused(
+                f"gang {gang.name} did not reconcile after removing the line: "
+                + "; ".join(problems)
+            )
+        fighters = len(ids)
+        said = f"gang {gang.name}: removed the line from {fighters} fighter{'' if fighters == 1 else 's'}"
+        # The row goes with the last fighter: after this gang, nothing
+        # may name it any more.
+        for label, pk in plan.targets:
+            row = apps.get_model(label).objects.filter(pk=pk).first()
+            if row is None:
+                continue
+            if not plan_deletion([row]).ok:
+                continue
+            authoring.delete_content(row)
+            said += f"; deleted {_said(row)}"
+        return said
 
 
 def apply(plan, actor=None):
@@ -663,6 +914,11 @@ def apply(plan, actor=None):
 
     if plan.refusals:
         raise Refused("nothing was deleted: " + "; ".join(plan.refusals))
+    if plan.lines:
+        raise Refused(
+            "nothing was deleted: fighters have this line, and it is removed "
+            "from them gang by gang, not here"
+        )
     if plan.nothing_here:
         return list(plan.preview())
 

--- a/n26/library/templates/authoring/_deletion_plan.html
+++ b/n26/library/templates/authoring/_deletion_plan.html
@@ -1,7 +1,8 @@
 {% comment %}
 What a delete would take, drawn on every page that asks the question:
-what goes, the test gangs that go with it, and what refuses it. Takes
-`counts`, `test_gangs` and `refusals` from _deletion_words in
+what goes, the fighters a firing line is removed from, the test gangs
+that go with it, and what refuses it. Takes `counts`, `lines`,
+`test_gangs` and `refusals` from _deletion_words in
 n26/library/views.py. Nothing here changes anything.
 {% endcomment %}
 {% if refusals %}
@@ -20,6 +21,36 @@ n26/library/views.py. Nothing here changes anything.
                     <tr>
                         <td class="w-full">{{ kind|capfirst }}</td>
                         <td class="text-right tabular-nums">{{ count }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </c-ui.table>
+    </c-n26.form-section>
+{% endif %}
+{% if lines and not refusals %}
+    <c-n26.form-section title="Fighters that have this line"
+                        description="Nobody paid for it: the weapon brought it. Deleting the line removes it from these fighters. Their gangs are not otherwise touched.">
+        <c-ui.table>
+            <thead>
+                <tr>
+                    <th scope="col">Gang</th>
+                    <th scope="col">Owner</th>
+                    <th scope="col" class="w-full">Fighters</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for line in lines %}
+                    <tr>
+                        <td class="whitespace-nowrap">
+                            {{ line.name }}
+                            {% if line.archived %}
+                                <c-ui.badge color="gray" size="sm" class="ml-1">
+                                    Archived
+                                </c-ui.badge>
+                            {% endif %}
+                        </td>
+                        <td class="whitespace-nowrap">{{ line.owner }}</td>
+                        <td class="text-muted">{{ line.fighters }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/n26/library/templates/authoring/weapon_profile_delete.html
+++ b/n26/library/templates/authoring/weapon_profile_delete.html
@@ -5,17 +5,19 @@ of its own. A page rather than a prompt: it survives a reload, Back is a
 real answer, and it works with scripting switched off. Nothing here
 changes anything — the form's POST is the act.
 
-Deleting is for the unused. Every reference protects the line — a gang
-that holds it, a list that offers it, a hire that comes with it as an
-ammo type — so a line anybody relies on is refused in words, and the way
-to make it deletable is to remove those references first.
+Deleting is for the unused. Every reference protects the line — a list
+that offers it, a hire that comes with it as an ammo type, a fighter
+who paid for it — so a line anybody relies on is refused in words. The
+one holder that does not refuse is a fighter the weapon brought the
+line to for nothing: the page names those fighters, and the line is
+removed from them before it goes.
 {% endcomment %}
 {% block head_title %}Delete {{ label }}{% endblock head_title %}
 {% block content %}
     <c-n26.form-page action="{% url 'authoring-weapon-profile-delete' thing.pk %}"
                      title="Delete {{ label }}?"
-                     lead="For good: the {{ verbose_name }} leaves {{ weapon }}, and its characteristics with it. There is no undo."
-                     submit_label="Delete it"
+                     lead="For good: the {{ verbose_name }} leaves {{ weapon }}, and its characteristics with it{% if lines %}. The fighters that have it lose the line{% endif %}. You cannot undo this."
+                     submit_label="{{ submit_label }}"
                      submit_variant="danger"
                      cancel_url="{{ back }}">
         <c-slot name="breadcrumb">
@@ -36,11 +38,13 @@ to make it deletable is to remove those references first.
             </c-ui.breadcrumbs>
         </c-slot>
         {% csrf_token %}
-        <c-ui.alert variant="info" title="Anything still using it refuses this">
-            A gang that holds it, a list that offers it, a hire that comes
-            with it as an ammo type — each protects it. If any exist,
-            nothing is deleted and this page says who they are.
-        </c-ui.alert>
+        {% include "authoring/_deletion_plan.html" %}
+        {% if not refusals and not lines and not test_gangs %}
+            <c-ui.alert variant="info" title="Nothing else holds it">
+                No fighter has it, no list offers it and no hire comes with
+                it, so only the line itself goes.
+            </c-ui.alert>
+        {% endif %}
         {% comment %}
         The weapon stands whatever happens here. Said because the control
         that leads here sits in a row of the weapon's own lines, where

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -2948,25 +2948,29 @@ def weapon_profile_delete(request, pk):
 
     A line is a part of its weapon rather than an authored kind, so the
     generic delete page — which reads a kind out of the address — cannot
-    ask for one. This is the same question at an address of its own.
-
-    Deleting is for the unused, and the act itself is the one every
-    delete page performs (``_deleting``): a line a gang holds, a list
-    offers, or a hire comes with as an ammo type is refused in words,
-    and nothing half-happens.
+    ask for one. This is the same question at an address of its own,
+    with one more ending: a weapon's free lines ride onto every fighter
+    that has the weapon, so a line only fighters have — nobody paid, and
+    nothing hangs off it — is removed from them, gang by gang, and then
+    deleted. A line a list offers, a hire comes with as an ammo type, or
+    anyone paid for is refused in words, as any held row is.
 
     The characteristics go with the line. The weapon and its other lines
     are untouched, and a weapon with none is a legitimate thing to have
     — an author part-way through correcting a table.
     """
+    from n26.library.deletion import plan_deletion
     from n26.library.models import WeaponProfile
 
     profile = get_object_or_404(WeaponProfile.objects.select_related("weapon"), pk=pk)
     weapon = profile.weapon
     back = reverse("authoring-detail", args=["weapon", weapon.pk])
+    label = _label_for(profile)
+    plan = plan_deletion([profile], remove_free_lines=True)
 
     if request.method == "POST":
-        return redirect(back if _deleting(request, profile) else request.path)
+        elsewhere = _perform_deletion(request, plan, label)
+        return elsewhere or redirect(back)
 
     return render(
         request,
@@ -2974,11 +2978,12 @@ def weapon_profile_delete(request, pk):
         {
             "kind": "weapon",
             "thing": profile,
-            "label": _label_for(profile),
+            "label": label,
             "weapon": weapon,
             "weapons_plural": str(weapon._meta.verbose_name_plural),
             "verbose_name": str(WeaponProfile._meta.verbose_name),
             "back": back,
+            **_deletion_words(plan, label),
         },
     )
 
@@ -3321,8 +3326,23 @@ def _deletion_words(plan, label):
         for holder in (*plan.test_gangs, *plan.test_campaigns)
     ]
     campaigns = sum(1 for holder in plan.test_campaigns)
+    lines = [
+        {
+            "name": line.name,
+            "owner": line.owner,
+            "archived": line.archived,
+            "fighters": ", ".join(line.fighters),
+        }
+        for line in plan.lines
+    ]
     if plan.refusals:
         submit_label = ""
+    elif lines:
+        n = plan.fighters_with_lines
+        submit_label = (
+            f"Delete the firing line and remove it from {n} "
+            f"fighter{'' if n == 1 else 's'}"
+        )
     elif gangs:
         n = len(plan.test_gangs)
         parts = [f"{n} test gang{'' if n == 1 else 's'}"] if n else []
@@ -3334,6 +3354,8 @@ def _deletion_words(plan, label):
     return {
         "plan": plan,
         "test_gangs": gangs,
+        "lines": lines,
+        "fighters_with_lines": plan.fighters_with_lines,
         "refusals": list(plan.refusals),
         "counts": sorted(plan.counts().items()),
         "submit_label": submit_label,
@@ -3352,7 +3374,7 @@ def _perform_deletion(request, plan, label):
     deleted here and the caller decides where to lead.
     """
     from n26.library.deletion import Refused, apply
-    from n26.maintenance import AnotherRunning, start_test_content_deletion
+    from n26.maintenance import AnotherRunning, start_authoring_deletion
 
     if plan.refusals:
         messages.error(
@@ -3364,7 +3386,7 @@ def _perform_deletion(request, plan, label):
         return redirect(request.path)
     if plan.touches_players:
         try:
-            record = start_test_content_deletion(plan, request.user)
+            record = start_authoring_deletion(plan, request.user)
         except AnotherRunning:
             messages.error(
                 request,
@@ -3462,9 +3484,9 @@ def deletion(request, pk):
     that asked for it cannot say how it ended. This one can, and it
     reloads itself until there is an ending to say.
     """
-    from n26.maintenance import test_content_deletion
+    from n26.maintenance import authoring_deletion
 
-    record = test_content_deletion(pk)
+    record = authoring_deletion(pk)
     if record is None:
         raise Http404("No such deletion")
     summary = record.summary or {}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -214,6 +214,10 @@ class Operation(models.TextChoices):
         "n26_delete_test_content",
         "n26: content is deleted along with the test gangs holding it",
     )
+    DELETE_FIRING_LINE = (
+        "n26_delete_firing_line",
+        "n26: a firing line is removed from the fighters that have it and deleted",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -233,6 +237,7 @@ LOCK_KEYS = {
     Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS: 826_020_618,
     Operation.SEED_JOURNAL_CONTENT: 826_020_619,
     Operation.DELETE_TEST_CONTENT: 826_020_620,
+    Operation.DELETE_FIRING_LINE: 826_020_621,
 }
 
 
@@ -2089,37 +2094,80 @@ def delete_test_content(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def delete_firing_line(backfill_id, **said_by_whoever_enqueued_it):
+    """Remove a free firing line from every fighter that has it, gang by
+    gang, and delete the row with the last of them.
+
+    Gang by gang because each gang is proved to reconcile around its
+    own commit, and a line a whole book of fighters carries is many
+    gangs; the walk records how far it got and hands the rest to a
+    fresh delivery.
+    """
+    from n26.library.deletion import (
+        DeletionPlan,
+        Refused,
+        free_line_removal,
+        remove_free_lines_from,
+    )
+
+    record = Backfill.objects.get(pk=backfill_id)
+    plan = DeletionPlan.from_record(record.summary)
+    run_per_gang(
+        backfill_id,
+        operation=Operation.DELETE_FIRING_LINE,
+        what="Firing line deletion",
+        find=lambda: free_line_removal(plan),
+        apply_one=lambda gang_id: remove_free_lines_from(gang_id, plan),
+        again=lambda: delete_firing_line.enqueue(backfill_id=backfill_id),
+        refusals=(Refused,),
+    )
+
+
+#: The operations the authoring delete pages ask for, and the task each
+#: runs on. A plan that removes a line from fighters walks gangs; one
+#: that deletes gangs holds everything in one transaction.
+AUTHORING_DELETIONS = {
+    Operation.DELETE_TEST_CONTENT: delete_test_content,
+    Operation.DELETE_FIRING_LINE: delete_firing_line,
+}
+
+
 class AnotherRunning(Exception):
     """A run of this operation is still going, so a second cannot start:
     the runner's lock would make it stand down without writing an
     ending, and its record would say running for ever."""
 
 
-def start_test_content_deletion(plan, user):
+def start_authoring_deletion(plan, user):
     """Record a deletion the authoring page asked for, and enqueue it.
 
     The record holds the plan as the page showed it, so the run can
     refuse if what stands has changed, and so the page that shows the
     outcome can say what was asked. Returns the record. Raises
-    :class:`AnotherRunning` while an earlier deletion is still going.
+    :class:`AnotherRunning` while an earlier run of the same kind is
+    still going.
     """
-    if running_guard(Operation.DELETE_TEST_CONTENT) is not None:
+    operation = (
+        Operation.DELETE_FIRING_LINE if plan.lines else Operation.DELETE_TEST_CONTENT
+    )
+    if running_guard(operation) is not None:
         raise AnotherRunning
     record = Backfill.objects.create(
-        operation=Operation.DELETE_TEST_CONTENT,
+        operation=operation,
         triggered_by=user,
         status=Backfill.Status.RUNNING,
         summary={**plan.as_record(), "attempts": 0},
     )
-    delete_test_content.enqueue(backfill_id=str(record.id))
+    AUTHORING_DELETIONS[operation].enqueue(backfill_id=str(record.id))
     return record
 
 
-def test_content_deletion(pk):
+def authoring_deletion(pk):
     """One deletion's record, for the page that shows its outcome — or
     None where no such record exists."""
     return Backfill.objects.filter(
-        pk=pk, operation=Operation.DELETE_TEST_CONTENT
+        pk=pk, operation__in=[op.value for op in AUTHORING_DELETIONS]
     ).first()
 
 
@@ -2137,10 +2185,25 @@ register_operation(
         ),
     )
 )
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.DELETE_FIRING_LINE.value,
+        name=Operation.DELETE_FIRING_LINE.label,
+        added=date(2026, 9, 9),
+        description=(
+            "Asked for from a firing line's delete page, not from here. "
+            "Removes a free firing line — one the weapon brought, that "
+            "nobody paid for — from every fighter that has it, gang by "
+            "gang, each gang proved to reconcile, and deletes the row "
+            "with the last of them."
+        ),
+    )
+)
 
 
 task_routes = [
     TaskRoute(delete_test_content, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(delete_firing_line, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_outcast_affiliation, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_chaos_god, ack_deadline=600, min_retry_delay=60),

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -3089,7 +3089,7 @@ class TestRemovingAFiringLine:
         body = client.get(self.address(warp)).content.decode()
 
         assert "Delete Warp round (Autogun)?" in body
-        assert "no undo" in body
+        assert "cannot undo" in body
         assert f'href="/n26/authoring/weapon/{autogun.pk}/"' in body
         assert WeaponProfile.objects.filter(pk=warp.pk).exists()
 
@@ -3132,7 +3132,7 @@ class TestRemovingAFiringLine:
 
         assert refused.redirect_chain[-1][0] == self.address(warp)
         assert "still in use" in body
-        assert f"— {member.default_set.name} point at it" in body
+        assert f"the built-in set “{member.default_set.name}” brings" in body
         assert "Ganger built-ins" == member.default_set.name
         assert WeaponProfile.objects.filter(pk=warp.pk).exists()
 
@@ -3167,9 +3167,10 @@ class TestRemovingAFiringLine:
 
         assert refused.redirect_chain[-1][0] == self.address(warp)
         assert "still in use" in body
-        assert "history, not clutter" in body
-        # An assignment's own words already name a second thing — whose
-        # it is — so it is said plainly rather than through a set.
+        # A paid line is history: the refusal names the gang and the
+        # fighter, and says what was paid for.
+        assert "paid for" in body
+        assert "The Armed" in body
         assert "Yolanda" in body
         assert WeaponProfile.objects.filter(pk=warp.pk).exists()
 

--- a/n26/tests/sandbox/test_firing_line_removal.py
+++ b/n26/tests/sandbox/test_firing_line_removal.py
@@ -1,0 +1,213 @@
+"""Deleting a firing line that fighters already have.
+
+A weapon's free lines ride along with it onto every fighter that has
+the weapon: nobody chose them and nobody paid. When an author deletes
+such a line — one added by mistake, say, to support a bundle the
+modifier already brings — the fighters that have it are not history
+being taken away; they are a grant being reversed. The delete page
+names them, and the line is removed from each, gang by gang, before the
+row goes (``n26/library/deletion.py``). A line somebody paid for
+refuses, as any held row does.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from gyrinx.maintenance.models import Backfill
+from n26.core.models import Assignment, Gang
+from n26.core.reconcile import assert_reconciled
+from n26.library.deletion import plan_deletion
+from n26.library.models import WeaponProfile
+from n26.tests.sandbox.actions import (
+    buy_weapon_profile,
+    create_gang_type,
+    create_profile,
+    create_weapon,
+    found_gang,
+    give_weapon,
+    hire,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def author(client):
+    user = User.objects.create_user("author", is_staff=True)
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def player(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def claw(default_pack):
+    """A weapon with its own line and a second free line that was never
+    needed: the bundle it comes with brings the thing itself."""
+    return create_weapon(
+        "Malcadon slashing claw",
+        price=30,
+        profiles=[("", 0), ("Web incisor", 0)],
+    )
+
+
+@pytest.fixture
+def incisor(claw):
+    return WeaponProfile.objects.get(weapon=claw, name="Web incisor")
+
+
+@pytest.fixture
+def escher(default_pack):
+    return create_gang_type("Escher", starting_credits=1000)
+
+
+@pytest.fixture
+def ganger(escher, person_type):
+    return create_profile("Ganger", person_type, escher, price=50)
+
+
+def armed(owner, name, escher, ganger, claw, fighters=1):
+    gang = found_gang(name, escher, owner=owner)
+    for n in range(fighters):
+        model = hire(gang, ganger, f"Fighter {n + 1}", paid=50)
+        give_weapon(model, claw, paid=30)
+    return gang
+
+
+def delete_page(line):
+    return f"/n26/authoring/weapon-profiles/{line.pk}/delete/"
+
+
+class TestNamingTheFighters:
+    def test_a_free_line_names_the_fighters_rather_than_refusing(
+        self, author, player, escher, ganger, claw, incisor
+    ):
+        mine = armed(author, "Mine", escher, ganger, claw)
+        theirs = armed(player, "Theirs", escher, ganger, claw, fighters=2)
+
+        plan = plan_deletion([incisor], remove_free_lines=True)
+
+        assert plan.ok
+        assert not plan.gangs
+        assert [line.name for line in plan.lines] == [mine.name, theirs.name]
+        assert plan.fighters_with_lines == 3
+        assert plan.touches_players
+        assert any(
+            "remove the firing line from 3 fighters" in w for w in plan.preview()
+        )
+
+    def test_without_asking_the_fighters_are_holders(
+        self, author, player, escher, ganger, claw, incisor
+    ):
+        armed(player, "Theirs", escher, ganger, claw)
+
+        plan = plan_deletion([incisor])
+
+        assert not plan.ok
+        assert not plan.lines
+
+    def test_a_paid_line_refuses(self, author, player, escher, ganger, claw):
+        from n26.library.authoring import add_weapon_profile
+
+        acid = add_weapon_profile(claw, name="Acid ammo", price=15)
+        theirs = armed(player, "Theirs", escher, ganger, claw)
+        weapon_line = Assignment.objects.get(gang_root=theirs, weapon=claw)
+        buy_weapon_profile(weapon_line, acid)
+
+        plan = plan_deletion([acid], remove_free_lines=True)
+
+        assert not plan.ok
+        assert any("paid for" in words for words in plan.refusals)
+        assert not plan.lines
+
+    def test_a_record_reads_back_with_its_lines(
+        self, author, player, escher, ganger, claw, incisor
+    ):
+        from n26.library.deletion import DeletionPlan
+
+        armed(player, "Theirs", escher, ganger, claw)
+        plan = plan_deletion([incisor], remove_free_lines=True)
+
+        again = DeletionPlan.from_record(plan.as_record())
+
+        assert again.same_as(plan)
+        assert again.fighters_with_lines == 1
+
+
+class TestThePage:
+    def test_it_names_the_fighters_and_counts_them_on_the_button(
+        self, author, client, player, escher, ganger, claw, incisor
+    ):
+        armed(author, "Mine", escher, ganger, claw)
+        armed(player, "Theirs", escher, ganger, claw, fighters=2)
+
+        body = client.get(delete_page(incisor)).content.decode()
+
+        assert "Fighters that have this line" in body
+        assert "Theirs" in body
+        assert "Fighter 1, Fighter 2" in body
+        assert "Delete the firing line and remove it from 3 fighters" in body
+
+    def test_deleting_removes_the_line_from_every_fighter_and_deletes_the_row(
+        self, author, client, player, escher, ganger, claw, incisor
+    ):
+        mine = armed(author, "Mine", escher, ganger, claw)
+        theirs = armed(player, "Theirs", escher, ganger, claw, fighters=2)
+
+        response = client.post(delete_page(incisor))
+
+        record = Backfill.objects.get()
+        assert record.operation == "n26_delete_firing_line"
+        assert response["Location"] == f"/n26/authoring/deletions/{record.pk}/"
+        assert record.status == Backfill.Status.DONE, record.error
+        assert not WeaponProfile.objects.filter(pk=incisor.pk).exists()
+        assert not Assignment.objects.filter(weapon_profile=incisor).exists()
+        # The weapon and its own line stay on every fighter.
+        assert Assignment.objects.filter(gang_root=theirs, weapon=claw).count() == 2
+        assert (
+            Assignment.objects.filter(
+                gang_root=theirs, weapon_profile__weapon=claw
+            ).count()
+            == 2
+        )
+        for gang in (Gang.objects.get(pk=mine.pk), Gang.objects.get(pk=theirs.pk)):
+            assert_reconciled(gang)
+        report = " ".join(record.summary["report"])
+        assert "Theirs: removed the line from 2 fighters" in report
+        assert "deleted" in report
+
+        body = client.get(response["Location"]).content.decode()
+        assert "Deleted" in body
+
+    def test_a_fighter_who_paid_since_the_page_was_read_stops_the_run(
+        self, author, client, player, escher, ganger, claw, incisor
+    ):
+        from n26.library.authoring import revise
+
+        theirs = armed(player, "Theirs", escher, ganger, claw)
+        body = client.get(delete_page(incisor)).content.decode()
+        assert "remove it from 1 fighter" in body
+        # A second fighter buys the line after the page was read.
+        revise(incisor, price=10)
+        second = hire(theirs, ganger, "Late", paid=50)
+        weapon_line = give_weapon(second, claw, paid=30)
+        buy_weapon_profile(weapon_line, incisor)
+
+        response = client.post(delete_page(incisor), follow=True)
+
+        assert "paid for" in response.content.decode()
+        assert WeaponProfile.objects.filter(pk=incisor.pk).exists()
+        assert not Backfill.objects.exists()
+
+    def test_an_unused_line_is_deleted_in_the_request(self, author, client, incisor):
+        body = client.get(delete_page(incisor)).content.decode()
+        assert "Nothing else holds it" in body
+
+        response = client.post(delete_page(incisor))
+
+        assert response.status_code == 302
+        assert not WeaponProfile.objects.filter(pk=incisor.pk).exists()
+        assert not Backfill.objects.exists()


### PR DESCRIPTION
Stacked on #2523.

The "Web incisor" firing line on the Malcadon slashing claw was added to support a bundle the modifier already brings, so it is not needed, and it cannot be deleted: every fighter who has the claw has the line, and each of those lines protects the row. Two fighters hold it on production, one of them on a live player's gang.

## What changes

**A firing line's delete page has a fourth ending.** A weapon's free lines ride onto every fighter that has the weapon: nobody chose them and nobody paid. Deleting such a line reverses a grant the content made rather than taking anyone's history away. The page now lists the fighters that have the line, by gang and owner, and the button reads "Delete the firing line and remove it from N fighters".

A line counts as free when it sits under its weapon's own assignment, its ledger entry and events carry no money and no rating, and nothing hangs off it. A line somebody paid for, or one with something under it, refuses in words as before, naming the gang and the fighter.

**The removal runs gang by gang** as `n26_delete_firing_line` on `run_per_gang`: each gang is locked, its part of the plan read again, the zero-value assignments deleted with their entries and events, the gang proved to reconcile before and after, and the row deleted by whichever gang finds nothing else naming it. A fighter who paid for the line after the page was read stops the run before anything goes. The author lands on the same outcome page as #2523.

Without the flag the planner behaves as in #2523: a player's fighter holding the line is a holder and refuses. Only the firing line page asks for the fourth ending, so "Delete everything staged" still refuses a staged line on a player's gang.

## Smoke test

On a fork of the content database: a weapon with its own line and a free "Web incisor" line, held by one of the author's fighters and two of a player's. The page named all three; the run removed the line from each, deleted the row with the last gang, left the weapon and its own line on every fighter, and both gangs reconcile. Screenshots checked.

## How to try it

1. Open a weapon's page, then a free line's own page, then Delete.
2. With fighters holding the weapon, the page lists them and the button counts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cZmwCpLyQVfART55StrdX
