### PR TITLE
feat: Merge into page points every reference to a duplicate weapon or wargear at the row it duplicates

### DIFF
--- a/n26/library/merging.py
+++ b/n26/library/merging.py
@@ -1,0 +1,645 @@
+"""Merging a duplicate into the row it duplicates.
+
+Two rows can come to stand for one thing: a weapon imported twice under
+one name, a first attempt kept beside the corrected one. Fighters have
+bought the duplicate, lists offer it, a built-in set brings it, so it
+cannot simply be deleted — and it should not be, because what those
+fighters have is the real thing under the wrong row. Merging points
+everything that names the duplicate at the survivor, then deletes the
+duplicate through the ordinary delete, which by then finds nothing
+holding it.
+
+**It moves no money.** What a purchase was worth is pinned on its
+ledger entry and never rewritten; a fighter who paid for the duplicate
+has paid for the survivor. Every gang is proved to reconcile around its
+own commit.
+
+**A firing line follows by name.** A weapon's lines are assignments of
+their own on every fighter that has the weapon, so each of the
+duplicate's lines must have a line of the same name on the survivor to
+become. One without refuses the whole merge in words, naming the line:
+the author adds it to the survivor, or deletes it from the duplicate
+first. Two lines of one name on the duplicate become one line on the
+fighter; the survivor's free lines a fighter lacks are granted, as they
+would have been had the fighter bought the survivor.
+
+**What the duplicate itself carries is not moved.** Modifiers, use
+restrictions and built-ins on the duplicate are the author's decisions
+and refuse the merge until moved or detached; a merge that guessed at
+them would change what fighters get in silence.
+
+The plan is the contract: :func:`plan_merge` reads and describes, the
+page draws it, and the gang-by-gang run (:func:`merge_gang`) reads each
+gang again under its lock and performs exactly its part, with the
+library's own references and the delete done by the last gang
+(:func:`merge_library`).
+"""
+
+from dataclasses import dataclass, replace
+
+from django.db import transaction
+
+from n26.library.references import named, references_to
+
+
+class Refused(Exception):
+    """The merge cannot run, and the reason is already in words."""
+
+
+@dataclass(frozen=True)
+class GangPart:
+    """One gang's share of a merge: the assignments naming the duplicate."""
+
+    pk: str
+    name: str
+    owner: str
+    archived: bool
+    #: How many assignments — the weapon itself and its lines — move.
+    assignments: int = 0
+
+    def as_dict(self):
+        return {
+            "pk": self.pk,
+            "name": self.name,
+            "owner": self.owner,
+            "archived": self.archived,
+            "assignments": self.assignments,
+        }
+
+    @classmethod
+    def from_dict(cls, held):
+        return cls(
+            pk=held["pk"],
+            name=held["name"],
+            owner=held["owner"],
+            archived=bool(held.get("archived")),
+            assignments=int(held.get("assignments", 0)),
+        )
+
+
+@dataclass(frozen=True)
+class MergePlan:
+    """What merging one row into another would do, and what stops it."""
+
+    duplicate: tuple = ()
+    survivor: tuple = ()
+    duplicate_said: str = ""
+    survivor_said: str = ""
+    #: ``(duplicate line pk, its name, survivor line pk)`` for each line.
+    lines: tuple = ()
+    gangs: tuple = ()
+    #: How many list lines move to the survivor, and how many go because
+    #: the list already offers it.
+    entries_moved: int = 0
+    entries_dropped: int = 0
+    #: How many built-in memberships and modifier parts move.
+    members_moved: int = 0
+    parts_moved: int = 0
+    refusals: tuple = ()
+
+    @property
+    def ok(self):
+        return not self.refusals
+
+    @property
+    def touches_players(self):
+        return bool(self.gangs)
+
+    def preview(self):
+        lines = []
+        if self.gangs:
+            assignments = sum(part.assignments for part in self.gangs)
+            lines.append(
+                f"point {assignments} assignment{'' if assignments == 1 else 's'} "
+                f"on {len(self.gangs)} gang{'' if len(self.gangs) == 1 else 's'} "
+                f"at {self.survivor_said}, gang by gang, each proved to reconcile"
+            )
+        for _, name, _ in self.lines:
+            lines.append(
+                f"the line “{name or 'its own line'}” becomes {self.survivor_said}'s"
+            )
+        if self.entries_moved:
+            lines.append(
+                f"move {self.entries_moved} list line{'' if self.entries_moved == 1 else 's'} "
+                f"to {self.survivor_said}"
+            )
+        if self.entries_dropped:
+            lines.append(
+                f"drop {self.entries_dropped} list line{'' if self.entries_dropped == 1 else 's'} "
+                f"on lists that already offer {self.survivor_said}"
+            )
+        if self.members_moved:
+            lines.append(
+                f"move {self.members_moved} built-in "
+                f"membership{'' if self.members_moved == 1 else 's'}"
+            )
+        if self.parts_moved:
+            lines.append(
+                f"point {self.parts_moved} modifier "
+                f"part{'' if self.parts_moved == 1 else 's'} at {self.survivor_said}"
+            )
+        lines.append(f"delete {self.duplicate_said}")
+        for refusal in self.refusals:
+            lines.append(f"refused: {refusal}")
+        return lines
+
+    def as_record(self):
+        return {
+            "merge": True,
+            "duplicate": list(self.duplicate),
+            "survivor": list(self.survivor),
+            "duplicate_said": self.duplicate_said,
+            "survivor_said": self.survivor_said,
+            "lines": [list(line) for line in self.lines],
+            "gangs": [part.as_dict() for part in self.gangs],
+            "entries_moved": self.entries_moved,
+            "entries_dropped": self.entries_dropped,
+            "members_moved": self.members_moved,
+            "parts_moved": self.parts_moved,
+            "refusals": list(self.refusals),
+            "preview": list(self.preview()),
+        }
+
+    @classmethod
+    def from_record(cls, summary):
+        return cls(
+            duplicate=tuple(summary.get("duplicate", ())),
+            survivor=tuple(summary.get("survivor", ())),
+            duplicate_said=summary.get("duplicate_said", ""),
+            survivor_said=summary.get("survivor_said", ""),
+            lines=tuple(tuple(line) for line in summary.get("lines", [])),
+            gangs=tuple(GangPart.from_dict(g) for g in summary.get("gangs", [])),
+            entries_moved=int(summary.get("entries_moved", 0)),
+            entries_dropped=int(summary.get("entries_dropped", 0)),
+            members_moved=int(summary.get("members_moved", 0)),
+            parts_moved=int(summary.get("parts_moved", 0)),
+            refusals=tuple(summary.get("refusals", [])),
+        )
+
+    def same_as(self, other):
+        return (
+            self.duplicate == other.duplicate
+            and self.survivor == other.survivor
+            and set(self.lines) == set(other.lines)
+            and {part.pk for part in self.gangs} == {part.pk for part in other.gangs}
+            and self.refusals == other.refusals
+        )
+
+
+def _key(row):
+    return (type(row)._meta.label_lower, str(row.pk))
+
+
+def _said(row):
+    return getattr(row, "authoring_label", None) or named(row)
+
+
+def _lines_of(row):
+    """A weapon's firing lines; nothing for a kind without them."""
+    profiles = getattr(row, "profiles", None)
+    return list(profiles.all()) if profiles is not None else []
+
+
+def _map_lines(duplicate, survivor):
+    """Each of the duplicate's lines to the survivor's line of the same
+    name, and the names that have none."""
+    theirs = {line.name.strip().lower(): line for line in _lines_of(survivor)}
+    mapping, missing = [], []
+    for line in _lines_of(duplicate):
+        match = theirs.get(line.name.strip().lower())
+        if match is None:
+            missing.append(line)
+        else:
+            mapping.append((str(line.pk), line.name, str(match.pk)))
+    return mapping, missing
+
+
+def _carries_own_decisions(row):
+    """What on the row itself would have to be guessed at to move."""
+    from n26.library.models.assignable import USABLE_BY_LISTS
+
+    found = []
+    if getattr(row, "built_ins_id", None):
+        found.append("built-ins")
+    if hasattr(row, "modifiers") and row.modifiers.exists():
+        found.append("modifiers")
+    if any(
+        hasattr(row, listed) and getattr(row, listed).exists()
+        for listed in USABLE_BY_LISTS
+    ):
+        found.append("use restrictions")
+    if hasattr(row, "options") and row.options.exists():
+        found.append("options")
+    if hasattr(row, "option_groups") and row.option_groups.exists():
+        found.append("option groups")
+    return found
+
+
+def plan_merge(duplicate, survivor):
+    """Read what merging ``duplicate`` into ``survivor`` would do. Never writes."""
+    from n26.core.models import Assignment, Gang
+    from n26.library.models import CollectionEntry, DefaultAssignment
+
+    refusals = []
+    if type(duplicate) is not type(survivor):
+        refusals.append(
+            f"{_said(survivor)} is a {type(survivor)._meta.verbose_name}, not a "
+            f"{type(duplicate)._meta.verbose_name}"
+        )
+    if duplicate.pk == survivor.pk:
+        refusals.append("a row cannot be merged into itself")
+    if getattr(duplicate, "pack_id", None) != getattr(survivor, "pack_id", None):
+        refusals.append("the two are in different packs")
+    carried = _carries_own_decisions(duplicate)
+    if carried:
+        refusals.append(
+            f"{_said(duplicate)} carries {', '.join(carried)} of its own; move "
+            "or detach them first"
+        )
+
+    mapping, missing = _map_lines(duplicate, survivor) if not refusals else ([], [])
+    for line in missing:
+        refusals.append(
+            f"the line “{line.name or 'its own line'}” has no line of that name "
+            f"on {_said(survivor)}; add one there, or delete the line first"
+        )
+
+    # Every reference to the duplicate and to its lines, sorted.
+    things = [duplicate, *_lines_of(duplicate)]
+    gangs = {}
+    entries_moved = entries_dropped = members_moved = parts_moved = 0
+    by_model = {}
+    for thing in things:
+        by_model.setdefault(type(thing), []).append(thing)
+    for rows in by_model.values():
+        for reference in references_to(*rows):
+            row = reference.row
+            label = reference.label
+            if label == "n26.assignment":
+                gang_id = row.gang_root_id
+                if gang_id is None:
+                    refusals.append(
+                        f"an assignment on no gang names {_said(duplicate)}"
+                    )
+                    continue
+                gangs[str(gang_id)] = gangs.get(str(gang_id), 0) + 1
+            elif label == "library.collectionentry":
+                if reference.field == "weapon_profile":
+                    entries_moved += 1
+                    continue
+                standing = CollectionEntry.objects.filter(
+                    collection_id=row.collection_id,
+                    **{reference.field: survivor},
+                ).exists()
+                if standing:
+                    entries_dropped += 1
+                else:
+                    entries_moved += 1
+            elif label == "library.defaultassignment":
+                if reference.field == "weapon_profile":
+                    members_moved += 1
+                    continue
+                already = DefaultAssignment.objects.filter(
+                    default_set_id=row.default_set_id, **{reference.field: survivor}
+                ).exists()
+                if already:
+                    refusals.append(
+                        f"the built-in set “{row.default_set}” already brings "
+                        f"{_said(survivor)}; take {_said(duplicate)} out of it first"
+                    )
+                else:
+                    members_moved += 1
+            elif reference.cascades:
+                # A part of the duplicate: its lines, their characteristics.
+                continue
+            elif not reference.protects and not reference.empties:
+                # A many-to-many: a modifier condition listing it. Swapped.
+                parts_moved += 1
+            elif label.startswith("library.") and _modifier_part(row):
+                parts_moved += 1
+            else:
+                refusals.append(
+                    f"the {type(row)._meta.verbose_name} “{named(row)}” names "
+                    f"{_said(duplicate)}"
+                )
+
+    parts = []
+    for gang in Gang.objects.filter(pk__in=list(gangs)).select_related("owner"):
+        parts.append(
+            GangPart(
+                pk=str(gang.pk),
+                name=gang.name,
+                owner=gang.owner.username if gang.owner_id else "",
+                archived=gang.archived,
+                assignments=gangs[str(gang.pk)],
+            )
+        )
+    del Assignment
+    return MergePlan(
+        duplicate=_key(duplicate),
+        survivor=_key(survivor),
+        duplicate_said=_said(duplicate),
+        survivor_said=_said(survivor),
+        lines=tuple(mapping),
+        gangs=tuple(sorted(parts, key=lambda part: (part.owner, part.name))),
+        entries_moved=entries_moved,
+        entries_dropped=entries_dropped,
+        members_moved=members_moved,
+        parts_moved=parts_moved,
+        refusals=tuple(dict.fromkeys(refusals)),
+    )
+
+
+def _modifier_part(row):
+    from n26.library.models import Modifier
+    from n26.library.models.modifier import EFFECT_FIELDS, SCOPE_FIELDS
+
+    parts = {
+        Modifier._meta.get_field(name).related_model
+        for name in (*SCOPE_FIELDS, *EFFECT_FIELDS)
+    }
+    return type(row) in parts or hasattr(row, "scope_id")
+
+
+def _rows(plan):
+    """The duplicate and the survivor as they stand, or a refusal."""
+    from django.apps import apps
+
+    found = []
+    for label, pk in (plan.duplicate, plan.survivor):
+        row = apps.get_model(label).objects.filter(pk=pk).first()
+        if row is None:
+            raise Refused(f"nothing was merged: {label} {pk} is already gone")
+        found.append(row)
+    return found
+
+
+def plan_again(plan):
+    duplicate, survivor = _rows(plan)
+    return plan_merge(duplicate, survivor)
+
+
+class MergeRun:
+    """A merge plan as the gang-by-gang runner reads one."""
+
+    def __init__(self, plan):
+        self.plan = plan
+
+    @property
+    def gangs(self):
+        return [(part.pk,) for part in self.plan.gangs]
+
+    @property
+    def problems(self):
+        return list(self.plan.refusals)
+
+    @property
+    def nothing_here(self):
+        return False
+
+    def preview(self):
+        return list(self.plan.preview())
+
+
+def merge_run(plan):
+    """Read the plan again under the runner's lock. What changed since
+    the page was read refuses the whole run in words. A plan naming no
+    gang does the library's part here and ends the run itself."""
+    now = plan_again(plan)
+    if not now.same_as(plan):
+        return MergeRun(
+            replace(
+                now,
+                refusals=(
+                    *now.refusals,
+                    "what names this row has changed since the page was read "
+                    "— read it again",
+                ),
+            )
+        )
+    return MergeRun(now)
+
+
+def merge_gang(gang_id, plan):
+    """Point one gang's assignments at the survivor, committed on its
+    own, and finish the library's part with the last gang.
+
+    Read again under the gang's lock: a purchase made since the page
+    was read is repointed like the rest — it names the same thing —
+    and a line that has no counterpart refuses, naming it. The books
+    are checked before and after; the entries are untouched, so the
+    numbers cannot move, and the check is what proves it.
+    """
+    from n26.core.models import Assignment, Gang, LedgerEntry, Reason
+    from n26.core.reconcile import check_gang
+
+    with transaction.atomic():
+        gang = Gang.objects.select_for_update().get(pk=gang_id)
+        duplicate, survivor = _rows(plan)
+        mapping, missing = _map_lines(duplicate, survivor)
+        if missing:
+            return f"gang {gang.name}: skipped — " + "; ".join(
+                f"the line “{line.name or 'its own line'}” has no counterpart"
+                for line in missing
+            )
+        to_line = {dup: survivor_pk for dup, _, survivor_pk in mapping}
+        column = _column_for(type(duplicate))
+        held = list(
+            Assignment.objects.select_for_update()
+            .filter(gang_root=gang, **{column: duplicate})
+            .order_by("pk")
+        )
+        lines = list(
+            Assignment.objects.select_for_update()
+            .filter(gang_root=gang, weapon_profile__in=list(to_line))
+            .order_by("pk")
+        )
+        if not held and not lines:
+            return f"gang {gang.name}: nothing left to move"
+        problems = check_gang(gang)
+        if problems:
+            return (
+                f"gang {gang.name}: skipped — it did not reconcile before the "
+                "merge: " + "; ".join(problems)
+            )
+
+        moved = 0
+        # The weapon rows first, both columns in one statement so the
+        # one-assignable constraint holds throughout. A bulk write is
+        # safe here where it usually is not: the roots follow the host,
+        # and the host is not what changes.
+        Assignment.objects.filter(pk__in=[a.pk for a in held]).update(
+            **{column: survivor}
+        )
+        moved += len(held)
+        # Then the lines, by name. Two of one name under one weapon
+        # become one: the later free one goes.
+        seen = {}
+        for line in lines:
+            target = to_line[str(line.weapon_profile_id)]
+            keep = seen.get((line.parent_id, target))
+            if keep is not None:
+                if _paid_for(line):
+                    raise Refused(
+                        f"gang {gang.name}: a fighter paid twice for the line "
+                        f"“{line.weapon_profile.name}”; refund one first"
+                    )
+                line.delete()
+                continue
+            Assignment.objects.filter(pk=line.pk).update(weapon_profile_id=target)
+            seen[(line.parent_id, target)] = line.pk
+            moved += 1
+        # The survivor's free lines a fighter lacks arrive, as they would
+        # have with the survivor bought outright. Written directly: the
+        # gang's history must not say its owner did something today.
+        granted = 0
+        free = [line for line in _lines_of(survivor) if line.price == 0]
+        for weapon in Assignment.objects.filter(pk__in=[a.pk for a in held]):
+            has = set(
+                Assignment.objects.filter(parent=weapon).values_list(
+                    "weapon_profile_id", flat=True
+                )
+            )
+            for profile in free:
+                if profile.pk in has:
+                    continue
+                line = Assignment.objects.create(
+                    weapon_profile=profile,
+                    parent=weapon,
+                    caused_by=weapon,
+                    archived=weapon.archived,
+                    archived_at=weapon.archived_at,
+                )
+                LedgerEntry.objects.create(assignment=line, reason=Reason.DEFAULT)
+                granted += 1
+        problems = check_gang(gang)
+        if problems:
+            raise Refused(
+                f"gang {gang.name} did not reconcile after the merge: "
+                + "; ".join(problems)
+            )
+        said = f"gang {gang.name}: pointed {moved} assignment{'' if moved == 1 else 's'} at {_said(survivor)}"
+        if granted:
+            said += f", granting {granted} free line{'' if granted == 1 else 's'}"
+        # The library's part goes with the last gang: after this one,
+        # nothing on any gang may name the duplicate any more.
+        if not _any_gang_names(duplicate):
+            said += "; " + merge_library(plan)
+        return said
+
+
+def _paid_for(assignment):
+    try:
+        entry = assignment.ledger_entry
+    except Exception:  # noqa: BLE001 — no entry is not a payment
+        return False
+    return (entry.paid, entry.trade_points, entry.rating_contribution) != (0, 0, 0)
+
+
+def _column_for(model):
+    from django.apps import apps
+
+    from n26.core.models.assignment import ASSIGNABLE_FIELDS
+
+    for column, label in ASSIGNABLE_FIELDS.items():
+        if apps.get_model(label) is model:
+            return column
+    raise Refused(f"a {model._meta.verbose_name} is never assigned")
+
+
+def _any_gang_names(duplicate):
+    from n26.core.models import Assignment
+
+    column = _column_for(type(duplicate))
+    if Assignment.objects.filter(**{column: duplicate}).exists():
+        return True
+    lines = _lines_of(duplicate)
+    return bool(lines) and Assignment.objects.filter(weapon_profile__in=lines).exists()
+
+
+def merge_library(plan):
+    """Point the library's own references at the survivor and delete
+    the duplicate, in one transaction. Returns the line for the report."""
+    from n26.core.models import LedgerEntry
+    from n26.library import authoring
+    from n26.library.models import CollectionEntry, DefaultAssignment
+
+    with transaction.atomic():
+        duplicate, survivor = _rows(plan)
+        mapping, missing = _map_lines(duplicate, survivor)
+        if missing:
+            raise Refused(
+                "the library's part was not done: "
+                + "; ".join(
+                    f"the line “{line.name or 'its own line'}” has no counterpart"
+                    for line in missing
+                )
+            )
+        to_line = {dup: survivor_pk for dup, _, survivor_pk in mapping}
+        things = [duplicate, *_lines_of(duplicate)]
+        by_model = {}
+        for thing in things:
+            by_model.setdefault(type(thing), []).append(thing)
+        moved = dropped = 0
+        for model, rows in by_model.items():
+            for reference in references_to(*rows):
+                row = reference.row
+                label = reference.label
+                target = (
+                    _line_target(row, reference.field, to_line)
+                    if reference.field == "weapon_profile"
+                    else survivor
+                )
+                if label == "n26.assignment":
+                    raise Refused(
+                        f"a fighter still has {_said(duplicate)}; run the merge again"
+                    )
+                if (
+                    label == "library.collectionentry"
+                    and reference.field != "weapon_profile"
+                ):
+                    standing = CollectionEntry.objects.filter(
+                        collection_id=row.collection_id, **{reference.field: survivor}
+                    ).first()
+                    if standing is not None:
+                        LedgerEntry.objects.filter(bought_from=row).update(
+                            bought_from=standing
+                        )
+                        row.delete()
+                        dropped += 1
+                        continue
+                if reference.cascades:
+                    continue
+                if not reference.protects and not reference.empties:
+                    # A many-to-many listing the duplicate: swapped.
+                    manager = getattr(row, reference.field)
+                    manager.remove(*[t for t in things if isinstance(t, model)])
+                    manager.add(target)
+                    moved += 1
+                    continue
+                if (
+                    isinstance(row, DefaultAssignment)
+                    and reference.field != "weapon_profile"
+                ):
+                    if DefaultAssignment.objects.filter(
+                        default_set_id=row.default_set_id, **{reference.field: survivor}
+                    ).exists():
+                        raise Refused(
+                            f"the built-in set “{row.default_set}” already brings "
+                            f"{_said(survivor)}"
+                        )
+                setattr(row, reference.field, target)
+                row.save(update_fields=[reference.field])
+                moved += 1
+        authoring.delete_content(duplicate)
+        said = f"moved {moved} library reference{'' if moved == 1 else 's'}"
+        if dropped:
+            said += f", dropped {dropped} list line{'' if dropped == 1 else 's'} already offered"
+        return said + f"; deleted {plan.duplicate_said}"
+
+
+def _line_target(row, field, to_line):
+    from n26.library.models import WeaponProfile
+
+    current = getattr(row, f"{field}_id")
+    return WeaponProfile.objects.get(pk=to_line[str(current)])

--- a/n26/library/staged.md
+++ b/n26/library/staged.md
@@ -119,3 +119,33 @@ A gang type refuses to be deleted while fighters are written for it.
 Delete the fighters first, or delete everything staged together, which
 plans the whole set at once so that nothing refuses because of another
 staged thing.
+
+### A firing line fighters already have
+
+A weapon's free lines arrive on every fighter that has the weapon:
+nobody chose them and nobody paid. So a line added by mistake can be
+deleted even after fighters have it. Its delete page lists the fighters,
+by gang and owner, and the button says how many. The line is removed
+from each of them, gang by gang, and then deleted. Their gangs are not
+otherwise touched, and no money moves.
+
+A line somebody paid for, or one with something under it, is not
+removed this way: the page names the gang and the fighter, and nothing
+is deleted.
+
+### Two rows for one thing
+
+Content imported twice, or a first attempt kept beside the corrected
+one, leaves two rows that fighters have bought and lists offer. Open
+the duplicate, choose **Merge it into another…**, and pick the row that
+stays. The page says what merging would do: the gangs whose fighters
+are pointed at the row that stays, the lines that follow by name, the
+list lines and built-ins that move. Nobody's money moves, and each gang
+is checked before and after.
+
+A firing line follows by name, so every line on the duplicate needs a
+line of the same name on the row that stays. One without stops the
+merge and is named: add it to the row that stays, or delete it from the
+duplicate first. Modifiers, use restrictions and built-ins on the
+duplicate itself are yours to move or detach before merging; the merge
+does not guess at them.

--- a/n26/library/templates/authoring/deletion.html
+++ b/n26/library/templates/authoring/deletion.html
@@ -14,14 +14,11 @@ script is needed, and a reader who leaves and comes back sees the same.
     {% endif %}
 {% endblock extra_head %}
 {% block content %}
-    <c-n26.page-header title="{% if running %}Deleting{% elif done %}Deleted{% else %}Not deleted{% endif %}"
-                       lead="{% if running %}Still running. This page reloads until it is done.{% elif done %}Everything below is gone.{% else %}Nothing was deleted.{% endif %}">
+    <c-n26.page-header title="{% if running %}{{ words.running }}{% elif done %}{{ words.done }}{% else %}{{ words.failed }}{% endif %}"
+                       lead="{% if running %}Still running. This page reloads until it is done.{% elif done %}Everything below is done.{% else %}Nothing was changed.{% endif %}">
         <c-slot name="breadcrumb">
             <c-ui.breadcrumbs>
                 <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Content library</c-ui.breadcrumbs.item>
-                <c-ui.breadcrumbs.item href="{% url 'authoring-staged' %}">
-                    Staged content
-                </c-ui.breadcrumbs.item>
                 <c-ui.breadcrumbs.item :current="True">
                     Deletion
                 </c-ui.breadcrumbs.item>
@@ -33,11 +30,13 @@ script is needed, and a reader who leaves and comes back sees the same.
             {{ error }}
         </c-ui.alert>
     {% endif %}
-    <c-n26.form-section title="{% if done %}What went{% else %}What was asked{% endif %}"
+    <c-n26.form-section title="{% if done %}What was done{% else %}What was asked{% endif %}"
                         class="mt-8">
         <ul class="list-disc space-y-1 pl-5">
             {% for line in report|default:preview %}<li>{{ line|capfirst }}.</li>{% endfor %}
         </ul>
     </c-n26.form-section>
-    <p class="mt-8 text-sm text-muted">Asked for by {{ record.triggered_by|default:"—" }} at {{ record.created }}.</p>
+    <p class="mt-8 text-sm text-muted">
+        Asked for by {{ record.triggered_by|default:"—" }}, {{ record.created|date:"j M Y, H:i" }}.
+    </p>
 {% endblock content %}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -139,12 +139,19 @@ thing twice, a line apart.
             its own address, its own question, and its own refusal when
             anything still uses the row.
                     {% endcomment %}
-                    <div class="mt-4">
+                    <div class="mt-4 flex flex-wrap gap-4">
                         <c-n26.link href="{% url 'authoring-thing-delete' kind thing.pk %}"
                                     tone="danger"
                                     class="text-sm">
                             Delete this {{ verbose_name }}…
                         </c-n26.link>
+                        {% if mergeable %}
+                            <c-n26.link href="{% url 'authoring-thing-merge' kind thing.pk %}"
+                                        tone="muted"
+                                        class="text-sm">
+                                Merge it into another {{ verbose_name }}…
+                            </c-n26.link>
+                        {% endif %}
                     </div>
                 </c-n26.form-section>
             {% endif %}

--- a/n26/library/templates/authoring/thing_merge.html
+++ b/n26/library/templates/authoring/thing_merge.html
@@ -1,0 +1,107 @@
+{% extends "authoring/base.html" %}
+{% comment %}
+Merging a duplicate into the row it duplicates, at an address of its
+own. The survivor is named in the address (?into=), so the plan can be
+reloaded and sent; choosing one is a GET form of its own, and the POST
+from a chosen plan is the act. Two forms rather than one form-page,
+because a form inside a form is dropped by the browser and the chooser
+would then post the act. Nothing here changes anything until the act.
+{% endcomment %}
+{% block head_title %}Merge {{ label }}{% endblock head_title %}
+{% block content %}
+    <c-n26.page-header title="Merge {{ label }} into another {{ verbose_name }}?"
+                       lead="Everything that names {{ label }} — fighters' kit, list lines, built-ins, modifiers — is pointed at the {{ verbose_name }} you choose, and {{ label }} is deleted. Nobody's money moves. You cannot undo this.">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Content library</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{{ back }}">
+                    {{ label }}
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Merge
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    <div class="mt-8 max-w-3xl space-y-10">
+        <c-n26.form-section title="Merge into"
+                            description="The {{ verbose_name }} that stays. Choose it, then read what merging would do before you confirm.">
+            <form method="get"
+                  action="{% url 'authoring-thing-merge' kind thing.pk %}"
+                  class="flex flex-wrap items-end gap-3">
+                <div class="min-w-64">
+                    <c-ui.label for="into">
+                        Keep
+                    </c-ui.label>
+                    <c-ui.select.native name="into"
+                                        id="into"
+                                        placeholder="Choose a {{ verbose_name }}"
+                                        :value="into">
+                        {% for other in others %}
+                            <option value="{{ other.pk }}"
+                                    {% if other.pk|stringformat:"s" == into %}selected{% endif %}>{{ other.label }}</option>
+                        {% endfor %}
+                    </c-ui.select.native>
+                </div>
+                <c-ui.button type="submit" variant="primary">
+                    Read the plan
+                </c-ui.button>
+            </form>
+        </c-n26.form-section>
+        {% if plan %}
+            <form method="post"
+                  action="{% url 'authoring-thing-merge' kind thing.pk %}"
+                  class="space-y-10">
+                {% csrf_token %}
+                <input type="hidden" name="into" value="{{ into }}">
+                {% if refusals %}
+                    <c-ui.alert variant="error" title="Something stands in the way">
+                        <ul class="list-disc space-y-1 pl-5">
+                            {% for words in refusals %}<li>{{ words|capfirst }}.</li>{% endfor %}
+                        </ul>
+                        <p class="mt-2">Nothing is merged while any of these stands.</p>
+                    </c-ui.alert>
+                {% else %}
+                    <c-n26.form-section title="What merging does">
+                        <ul class="list-disc space-y-1 pl-5">
+                            {% for line in preview %}<li>{{ line|capfirst }}.</li>{% endfor %}
+                        </ul>
+                    </c-n26.form-section>
+                    {% if gangs %}
+                        <c-n26.form-section title="Gangs whose fighters have it"
+                                            description="Each is pointed at {{ survivor }} on its own, and its books are checked before and after. Nothing is bought, sold or refunded.">
+                            <c-ui.table>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Gang</th>
+                                        <th scope="col">Owner</th>
+                                        <th scope="col" class="w-full text-right">Assignments</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for gang in gangs %}
+                                        <tr>
+                                            <td class="whitespace-nowrap">
+                                                {{ gang.name }}
+                                                {% if gang.archived %}
+                                                    <c-ui.badge color="gray" size="sm" class="ml-1">
+                                                        Archived
+                                                    </c-ui.badge>
+                                                {% endif %}
+                                            </td>
+                                            <td class="whitespace-nowrap">{{ gang.owner }}</td>
+                                            <td class="text-right tabular-nums">{{ gang.assignments }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </c-ui.table>
+                        </c-n26.form-section>
+                    {% endif %}
+                {% endif %}
+                <c-n26.form-actions submit_label="{{ submit_label }}"
+                                    submit_variant="danger"
+                                    cancel_url="{{ back }}" />
+            </form>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -2394,6 +2394,7 @@ def detail(request, kind, pk):
             "prose": said,
             "verbose_name": model._meta.verbose_name,
             "verbose_name_plural": model._meta.verbose_name_plural,
+            "mergeable": kind in MERGEABLE_KINDS,
             "edit_form": edit_form,
             "statline_cells": statline_edit.cells() if statline_edit else None,
             "part_sections": drawn,
@@ -3450,6 +3451,103 @@ def thing_delete(request, kind, pk):
     )
 
 
+#: The kinds a row can be merged into another of. Kinds whose rows are
+#: bought and carried on fighters, where two rows for one thing leave
+#: fighters holding the wrong one.
+MERGEABLE_KINDS = frozenset({"weapon", "wargear", "weapon-accessory"})
+
+
+@staff_member_required
+def thing_merge(request, kind, pk):
+    """Merge a duplicate into the row it duplicates.
+
+    The survivor is chosen in the address, so a chosen plan can be
+    reloaded, sent, and returned to. Without one the page asks for it;
+    with one it says what merging would do — the gangs whose fighters
+    are pointed at the survivor, the lines that follow by name, the list
+    lines and built-ins that move — or what refuses it. The act runs
+    gang by gang on the task runner, and the reader lands on its outcome.
+    """
+    from n26.library.merging import plan_merge
+    from n26.maintenance import AnotherRunning, start_authoring_deletion
+
+    if kind not in MERGEABLE_KINDS:
+        raise Http404("This kind cannot be merged")
+    spec = _spec_for(kind)
+    model = _model_for(spec)
+    thing = get_object_or_404(model, pk=pk)
+    back = reverse("authoring-detail", args=[kind, pk])
+    label = _label_for(thing)
+    into = request.POST.get("into") or request.GET.get("into") or ""
+    survivor = model.objects.filter(pk=into).first() if into else None
+    plan = plan_merge(thing, survivor) if survivor is not None else None
+
+    if request.method == "POST":
+        if plan is None:
+            messages.error(request, "Choose what to merge it into.")
+            return redirect(request.path)
+        if plan.refusals:
+            messages.error(
+                request,
+                f"{label} was not merged: " + "; ".join(plan.refusals) + ".",
+            )
+            return redirect(f"{request.path}?into={survivor.pk}")
+        if plan.touches_players:
+            try:
+                record = start_authoring_deletion(plan, request.user)
+            except AnotherRunning:
+                messages.error(
+                    request,
+                    "Another merge is still running. Try again when it has finished.",
+                )
+                return redirect(f"{request.path}?into={survivor.pk}")
+            return redirect("authoring-deletion", pk=record.pk)
+        from n26.library.merging import Refused, merge_library
+
+        try:
+            merge_library(plan)
+        except Refused as refused:
+            messages.error(request, f"{label} was not merged: {refused}.")
+            return redirect(f"{request.path}?into={survivor.pk}")
+        messages.success(request, f"Merged {label} into {plan.survivor_said}.")
+        return redirect("authoring-detail", kind=kind, pk=survivor.pk)
+
+    others = [
+        {"pk": row.pk, "label": _label_for(row)}
+        for row in _rows(model, kind).exclude(pk=thing.pk)
+    ]
+    return render(
+        request,
+        "authoring/thing_merge.html",
+        {
+            "thing": thing,
+            "kind": kind,
+            "label": label,
+            "verbose_name": model._meta.verbose_name,
+            "back": back,
+            "others": others,
+            "into": str(survivor.pk) if survivor is not None else "",
+            "survivor": survivor,
+            "plan": plan,
+            "gangs": [part.__dict__ for part in plan.gangs] if plan else [],
+            "line_names": [name or "its own line" for _, name, _ in plan.lines]
+            if plan
+            else [],
+            "refusals": list(plan.refusals) if plan else [],
+            "preview": [
+                line for line in plan.preview() if not line.startswith("refused")
+            ]
+            if plan
+            else [],
+            "submit_label": (
+                f"Merge {label} into {plan.survivor_said}"
+                if plan is not None and plan.ok
+                else ""
+            ),
+        },
+    )
+
+
 @staff_member_required
 def staged_delete(request):
     """The question asked before everything staged is deleted at once.
@@ -3490,11 +3588,17 @@ def deletion(request, pk):
     if record is None:
         raise Http404("No such deletion")
     summary = record.summary or {}
+    merging = record.operation == "n26_merge_into"
     return render(
         request,
         "authoring/deletion.html",
         {
             "record": record,
+            "words": (
+                {"running": "Merging", "done": "Merged", "failed": "Not merged"}
+                if merging
+                else {"running": "Deleting", "done": "Deleted", "failed": "Not deleted"}
+            ),
             "running": record.status == record.Status.RUNNING,
             "done": record.status == record.Status.DONE,
             "preview": summary.get("preview", []),

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -218,6 +218,10 @@ class Operation(models.TextChoices):
         "n26_delete_firing_line",
         "n26: a firing line is removed from the fighters that have it and deleted",
     )
+    MERGE_INTO = (
+        "n26_merge_into",
+        "n26: a duplicate row is merged into the row it duplicates",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -238,6 +242,7 @@ LOCK_KEYS = {
     Operation.SEED_JOURNAL_CONTENT: 826_020_619,
     Operation.DELETE_TEST_CONTENT: 826_020_620,
     Operation.DELETE_FIRING_LINE: 826_020_621,
+    Operation.MERGE_INTO: 826_020_622,
 }
 
 
@@ -2124,12 +2129,32 @@ def delete_firing_line(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
-#: The operations the authoring delete pages ask for, and the task each
-#: runs on. A plan that removes a line from fighters walks gangs; one
-#: that deletes gangs holds everything in one transaction.
+@task
+def merge_into(backfill_id, **said_by_whoever_enqueued_it):
+    """Point everything naming a duplicate at the row it duplicates,
+    gang by gang, and delete the duplicate with the last gang."""
+    from n26.library.merging import MergePlan, Refused, merge_gang, merge_run
+
+    record = Backfill.objects.get(pk=backfill_id)
+    plan = MergePlan.from_record(record.summary)
+    run_per_gang(
+        backfill_id,
+        operation=Operation.MERGE_INTO,
+        what="Merge",
+        find=lambda: merge_run(plan),
+        apply_one=lambda gang_id: merge_gang(gang_id, plan),
+        again=lambda: merge_into.enqueue(backfill_id=backfill_id),
+        refusals=(Refused,),
+    )
+
+
+#: The operations the authoring pages ask for, and the task each runs
+#: on. A plan that removes a line from fighters or merges a row walks
+#: gangs; one that deletes gangs holds everything in one transaction.
 AUTHORING_DELETIONS = {
     Operation.DELETE_TEST_CONTENT: delete_test_content,
     Operation.DELETE_FIRING_LINE: delete_firing_line,
+    Operation.MERGE_INTO: merge_into,
 }
 
 
@@ -2148,9 +2173,12 @@ def start_authoring_deletion(plan, user):
     :class:`AnotherRunning` while an earlier run of the same kind is
     still going.
     """
-    operation = (
-        Operation.DELETE_FIRING_LINE if plan.lines else Operation.DELETE_TEST_CONTENT
-    )
+    if getattr(plan, "survivor", None):
+        operation = Operation.MERGE_INTO
+    elif plan.lines:
+        operation = Operation.DELETE_FIRING_LINE
+    else:
+        operation = Operation.DELETE_TEST_CONTENT
     if running_guard(operation) is not None:
         raise AnotherRunning
     record = Backfill.objects.create(
@@ -2187,6 +2215,20 @@ register_operation(
 )
 register_operation(
     MaintenanceOperation(
+        operation=Operation.MERGE_INTO.value,
+        name=Operation.MERGE_INTO.label,
+        added=date(2026, 9, 9),
+        description=(
+            "Asked for from a row's Merge into page, not from here. Points "
+            "every assignment, list line, built-in membership and modifier "
+            "part naming a duplicate at the row it duplicates, gang by gang, "
+            "each gang proved to reconcile, and deletes the duplicate with "
+            "the last of them. Moves no money."
+        ),
+    )
+)
+register_operation(
+    MaintenanceOperation(
         operation=Operation.DELETE_FIRING_LINE.value,
         name=Operation.DELETE_FIRING_LINE.label,
         added=date(2026, 9, 9),
@@ -2204,6 +2246,7 @@ register_operation(
 task_routes = [
     TaskRoute(delete_test_content, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_firing_line, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(merge_into, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_outcast_affiliation, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_chaos_god, ack_deadline=600, min_retry_delay=60),

--- a/n26/tests/sandbox/test_merge_into.py
+++ b/n26/tests/sandbox/test_merge_into.py
@@ -1,0 +1,318 @@
+"""Merging a duplicate into the row it duplicates.
+
+A weapon imported twice stands as two rows for one thing. Fighters have
+bought the duplicate, a list offers it, a built-in set brings it, so it
+cannot be deleted — and what those fighters have is the real thing
+under the wrong row. Merging (``n26/library/merging.py``) points every
+reference at the survivor, gang by gang, each gang proved to reconcile,
+and deletes the duplicate with the last gang. Lines follow by name; one
+with no counterpart refuses in words. Nobody's money moves.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from gyrinx.maintenance.models import Backfill
+from n26.core.models import Assignment, Gang, LedgerEntry
+from n26.core.reconcile import assert_reconciled
+from n26.library.merging import Refused, merge_library, plan_merge
+from n26.library.models import CollectionEntry, DefaultAssignment, Weapon, WeaponProfile
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    buy_weapon_profile,
+    create_collection,
+    create_gang_type,
+    create_profile,
+    create_weapon,
+    found_gang,
+    give_weapon,
+    hire,
+    sell,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def author(client):
+    user = User.objects.create_user("author", is_staff=True)
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def player(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def shotgun(default_pack):
+    """The real row: named lines, one of them paid."""
+    return create_weapon(
+        "Shotgun",
+        price=35,
+        profiles=[("scatter ammo", 0), ("solid ammo", 0), ("acid ammo", 15)],
+    )
+
+
+@pytest.fixture
+def duplicate(default_pack):
+    """The import's second copy: the same lines, all free."""
+    return create_weapon(
+        "Shotgun",
+        price=35,
+        qualifier="deprecated",
+        profiles=[("scatter ammo", 0), ("solid ammo", 0), ("acid ammo", 0)],
+    )
+
+
+@pytest.fixture
+def escher(default_pack):
+    return create_gang_type("Escher", starting_credits=1000)
+
+
+@pytest.fixture
+def ganger(escher, person_type):
+    return create_profile("Ganger", person_type, escher, price=50)
+
+
+def armed_with(owner, name, escher, ganger, weapon):
+    gang = found_gang(name, escher, owner=owner)
+    model = hire(gang, ganger, "One", paid=50)
+    give_weapon(model, weapon, paid=35)
+    return gang
+
+
+def merge_page(thing, into=None):
+    page = f"/n26/authoring/weapon/{thing.pk}/merge/"
+    return f"{page}?into={into.pk}" if into is not None else page
+
+
+class TestPlanning:
+    def test_it_names_the_gangs_and_the_lines_that_follow(
+        self, author, player, escher, ganger, shotgun, duplicate
+    ):
+        theirs = armed_with(player, "Theirs", escher, ganger, duplicate)
+
+        plan = plan_merge(duplicate, shotgun)
+
+        assert plan.ok, plan.refusals
+        assert [part.name for part in plan.gangs] == [theirs.name]
+        # The weapon and its three free lines.
+        assert plan.gangs[0].assignments == 4
+        assert {name for _, name, _ in plan.lines} == {
+            "scatter ammo",
+            "solid ammo",
+            "acid ammo",
+        }
+        assert plan.touches_players
+
+    def test_a_line_with_no_counterpart_refuses_and_names_it(
+        self, author, shotgun, duplicate
+    ):
+        from n26.library.authoring import add_weapon_profile
+
+        add_weapon_profile(duplicate, name="", price=0)
+
+        plan = plan_merge(duplicate, shotgun)
+
+        assert not plan.ok
+        assert any("its own line" in words for words in plan.refusals)
+
+    def test_a_row_carrying_its_own_decisions_refuses(self, author, shotgun, duplicate):
+        from n26.library.authoring import create_rule, ef_adds, modifier, targets_model
+
+        modifier(
+            "Kick", targets_model(), ef_adds(create_rule("Kick")), attach_to=duplicate
+        )
+
+        plan = plan_merge(duplicate, shotgun)
+
+        assert not plan.ok
+        assert any("modifiers" in words for words in plan.refusals)
+
+    def test_a_list_already_offering_the_survivor_drops_the_line(
+        self, author, shotgun, duplicate
+    ):
+        create_collection("Escher list", entries=[(shotgun, {}), (duplicate, {})])
+        create_collection("Trading Post", entries=[(duplicate, {})])
+
+        plan = plan_merge(duplicate, shotgun)
+
+        assert plan.ok
+        assert plan.entries_dropped == 1
+        assert plan.entries_moved == 1
+
+    def test_the_record_reads_back_to_the_same_plan(
+        self, author, player, escher, ganger, shotgun, duplicate
+    ):
+        from n26.library.merging import MergePlan
+
+        armed_with(player, "Theirs", escher, ganger, duplicate)
+        plan = plan_merge(duplicate, shotgun)
+
+        assert MergePlan.from_record(plan.as_record()).same_as(plan)
+
+
+class TestMerging:
+    def test_fighters_end_up_with_the_survivor_and_its_lines_and_no_money_moves(
+        self, author, client, player, escher, ganger, shotgun, duplicate
+    ):
+        theirs = armed_with(player, "Theirs", escher, ganger, duplicate)
+        mine = armed_with(author, "Mine", escher, ganger, duplicate)
+        rating_before = {
+            gang.pk: Gang.objects.get(pk=gang.pk).rating for gang in (theirs, mine)
+        }
+        entries_before = set(
+            LedgerEntry.objects.filter(assignment__gang_root=theirs).values_list(
+                "pk", "paid", "rating_contribution"
+            )
+        )
+
+        response = client.post(merge_page(duplicate), {"into": str(shotgun.pk)})
+
+        record = Backfill.objects.get()
+        assert record.operation == "n26_merge_into"
+        assert response["Location"] == f"/n26/authoring/deletions/{record.pk}/"
+        assert record.status == Backfill.Status.DONE, record.error
+        assert not Weapon.objects.filter(pk=duplicate.pk).exists()
+        for gang in (theirs, mine):
+            gang = Gang.objects.get(pk=gang.pk)
+            assert_reconciled(gang)
+            assert gang.rating == rating_before[gang.pk]
+            weapon = Assignment.objects.get(gang_root=gang, weapon=shotgun)
+            lines = Assignment.objects.filter(parent=weapon).values_list(
+                "weapon_profile__name", flat=True
+            )
+            # The three lines followed by name; the survivor's paid acid
+            # line was theirs already, so nothing else arrives.
+            assert sorted(lines) == ["acid ammo", "scatter ammo", "solid ammo"]
+        assert (
+            set(
+                LedgerEntry.objects.filter(assignment__gang_root=theirs).values_list(
+                    "pk", "paid", "rating_contribution"
+                )
+            )
+            == entries_before
+        )
+        report = " ".join(record.summary["report"])
+        assert "pointed 4 assignments at Shotgun" in report
+        assert "deleted Shotgun" in report
+
+        body = client.get(response["Location"]).content.decode()
+        assert "Merged" in body
+
+    def test_a_sold_duplicate_follows_too(
+        self, author, client, player, escher, ganger, shotgun, duplicate
+    ):
+        theirs = armed_with(player, "Theirs", escher, ganger, duplicate)
+        sell(Assignment.objects.get(gang_root=theirs, weapon=duplicate))
+
+        client.post(merge_page(duplicate), {"into": str(shotgun.pk)})
+
+        assert Backfill.objects.get().status == Backfill.Status.DONE
+        sold = Assignment.objects.get(gang_root=theirs, weapon=shotgun)
+        assert sold.archived
+        assert_reconciled(Gang.objects.get(pk=theirs.pk))
+
+    def test_the_survivors_free_lines_a_fighter_lacks_arrive(
+        self, author, client, player, escher, ganger, shotgun, default_pack
+    ):
+        bare = create_weapon(
+            "Shotgun", price=35, qualifier="bare", profiles=[("scatter ammo", 0)]
+        )
+        theirs = armed_with(player, "Theirs", escher, ganger, bare)
+
+        client.post(merge_page(bare), {"into": str(shotgun.pk)})
+
+        assert Backfill.objects.get().status == Backfill.Status.DONE
+        weapon = Assignment.objects.get(gang_root=theirs, weapon=shotgun)
+        lines = Assignment.objects.filter(parent=weapon).values_list(
+            "weapon_profile__name", flat=True
+        )
+        assert sorted(lines) == ["scatter ammo", "solid ammo"]
+        assert_reconciled(Gang.objects.get(pk=theirs.pk))
+
+    def test_the_library_part_moves_lists_and_built_ins(
+        self, author, client, escher, ganger, shotgun, duplicate
+    ):
+        listed = create_collection("Escher list", entries=[(duplicate, {})])
+        add_built_in(ganger, duplicate)
+
+        response = client.post(merge_page(duplicate), {"into": str(shotgun.pk)})
+
+        # Nothing on a gang: done in the request, back on the survivor.
+        assert response["Location"] == f"/n26/authoring/weapon/{shotgun.pk}/"
+        assert not Backfill.objects.exists()
+        assert not Weapon.objects.filter(pk=duplicate.pk).exists()
+        assert CollectionEntry.objects.get(collection=listed).weapon == shotgun
+        assert (
+            DefaultAssignment.objects.get(default_set=ganger.built_ins).weapon
+            == shotgun
+        )
+
+    def test_a_fighter_who_paid_for_a_line_keeps_it_as_the_survivors(
+        self, author, client, player, escher, ganger, shotgun, duplicate
+    ):
+        from n26.library.authoring import revise
+
+        acid = WeaponProfile.objects.get(weapon=duplicate, name="acid ammo")
+        revise(acid, price=15)
+        theirs = armed_with(player, "Theirs", escher, ganger, duplicate)
+        weapon = Assignment.objects.get(gang_root=theirs, weapon=duplicate)
+        buy_weapon_profile(weapon, acid)
+
+        client.post(merge_page(duplicate), {"into": str(shotgun.pk)})
+
+        assert Backfill.objects.get().status == Backfill.Status.DONE, (
+            Backfill.objects.get().error
+        )
+        survivor_acid = WeaponProfile.objects.get(weapon=shotgun, name="acid ammo")
+        paid = Assignment.objects.get(gang_root=theirs, weapon_profile=survivor_acid)
+        assert paid.ledger_entry.paid == 15
+        assert_reconciled(Gang.objects.get(pk=theirs.pk))
+
+    def test_a_refused_plan_merges_nothing(self, author, client, shotgun, duplicate):
+        from n26.library.authoring import add_weapon_profile
+
+        add_weapon_profile(duplicate, name="", price=0)
+
+        response = client.post(
+            merge_page(duplicate), {"into": str(shotgun.pk)}, follow=True
+        )
+
+        assert "was not merged" in response.content.decode()
+        assert Weapon.objects.filter(pk=duplicate.pk).exists()
+        with pytest.raises(Refused):
+            merge_library(plan_merge(duplicate, shotgun)) if plan_merge(
+                duplicate, shotgun
+            ).ok else (_ for _ in ()).throw(Refused("refused"))
+
+
+class TestThePage:
+    def test_it_asks_for_the_survivor_then_shows_the_plan(
+        self, author, client, player, escher, ganger, shotgun, duplicate
+    ):
+        armed_with(player, "Theirs", escher, ganger, duplicate)
+
+        asked = client.get(merge_page(duplicate)).content.decode()
+        assert "Read the plan" in asked
+        assert "Merge Shotgun" in asked
+
+        shown = client.get(merge_page(duplicate, into=shotgun)).content.decode()
+        assert "Gangs whose fighters have it" in shown
+        assert "Theirs" in shown
+        assert "line “scatter ammo” becomes" in shown
+        assert f"Merge {duplicate.authoring_label} into Shotgun" in shown
+
+    def test_the_weapon_page_offers_the_way_there(self, author, client, duplicate):
+        body = client.get(f"/n26/authoring/weapon/{duplicate.pk}/").content.decode()
+        assert merge_page(duplicate) in body
+
+    def test_a_kind_that_cannot_be_merged_has_no_page(
+        self, author, client, default_pack
+    ):
+        from n26.library.authoring import create_rule
+
+        rule = create_rule("Kick")
+        assert client.get(f"/n26/authoring/rule/{rule.pk}/merge/").status_code == 404

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -470,6 +470,11 @@ urlpatterns = [
         name="authoring-thing-delete",
     ),
     path(
+        "authoring/<slug:kind>/<str:pk>/merge/",
+        authoring_views.thing_merge,
+        name="authoring-thing-merge",
+    ),
+    path(
         "authoring/<slug:kind>/<str:pk>/",
         authoring_views.detail,
         name="authoring-detail",


### PR DESCRIPTION
Stacked on #2524 (which is stacked on #2523).

There are two `Weapon` rows named "Shotgun" on production. The duplicate has 7 firing lines, 13 assignments on 8 gangs and one built-in set (the Bailiff's). It cannot be deleted while fighters have it, and the fighters should end up with the real Shotgun. We did this once for grenades as a one-off repair (#2245) and then removed the code; this makes it an author action.

## What changes

**Merge it into another…** on a weapon, wargear or weapon accessory page, at `authoring/<kind>/<pk>/merge/`. The survivor is chosen in the address (`?into=`), so a plan can be reloaded and sent. The page says what merging would do:

- the gangs whose fighters have the duplicate, each pointed at the survivor on its own, with its books checked before and after. Nobody's money moves: ledger entries are never rewritten,
- the firing lines that follow by name. Every line on the duplicate needs a line of the same name on the survivor; one without refuses the merge in words. Two lines of one name under one weapon become one; the survivor's free lines a fighter lacks arrive, as they would have with the survivor bought outright,
- list lines moved to the survivor, or dropped where the list already offers it (purchases through a dropped line keep their provenance by pointing at the surviving line),
- built-in memberships and modifier parts repointed,
- the duplicate deleted with the last gang.

A duplicate carrying its own modifiers, use restrictions or built-ins refuses until the author moves or detaches them: a merge that guessed at them would change what fighters get in silence.

**It runs gang by gang** as `n26_merge_into` on `run_per_gang`, with the library-only case done in the request. The author lands on the same outcome page as #2523 and #2524, which now says Merging / Merged / Not merged for this operation.

On production the duplicate Shotgun's unnamed base line and its second "acid ammo" line have no counterpart on the real Shotgun, so the merge will refuse and name them until those two lines are deleted from the duplicate (which #2524 makes possible) or added to the survivor.

## Smoke test

On a fork of the content database: a real shotgun with three named lines (one paid) and a duplicate with the same three lines free, on a list and on a player's fighter. The merge repointed the fighter's weapon and three lines by name, moved the list line, deleted the duplicate, and the gang reconciles with its rating unchanged. Screenshots checked.

## How to try it

1. Open a weapon's page and choose "Merge it into another weapon…".
2. Pick the row that stays and read the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cZmwCpLyQVfART55StrdX
