### PR TITLE
feat: a weapon's augmentation choice draws under the weapon row; an item holds one level

### DIFF
--- a/.claude/notes/issue-2313-plan.md
+++ b/.claude/notes/issue-2313-plan.md
@@ -413,6 +413,14 @@ test ends with `assert_reconciled(gang)`.
    Tests: the count zeroes, the penalty picks go, the history reads.
 6. **Words and drawing.** The note on the augmentation choice, the Hunt
    Master sentence, `recipes.md`, a gallery sample. Copywriter pass.
+   **Tom, 2026-09-10, after using it:** it is not clear at all that a
+   Power Boost result spends four Kill Count. The Power Boost line and
+   the pick screen must say so before a pick is made — the counter, the
+   four, and that a result taken back does not give them back. Also
+   from the same session: the picker now returns the reader to the
+   screen it was opened from (a `return` address carried on the link and
+   through the form, checked against this host), which every picker
+   link should pass — the gang sheet's do not yet.
 
 A feature flag is probably unnecessary — nothing draws until the content
 exists — but `n26/flags.py` is one line if 3 and 4 must land ahead of it.

--- a/.claude/notes/issue-2313-plan.md
+++ b/.claude/notes/issue-2313-plan.md
@@ -336,7 +336,16 @@ test ends with `assert_reconciled(gang)`.
    result taken back drops its rating but not the spend. Stat limits
    (library 0093) now clamp a capped characteristic, so a wasted result
    reads as no change rather than a breach.
-4. **The tier draws under its weapon.** Decided by Tom 2026-09-09 after
+4. **The tier draws under its weapon, and an item holds one level.**
+   Decided by Tom 2026-09-10: the rules give each item one augmentation
+   level, and n23's content restates the lower rungs' effects on each
+   higher rung, so the slot takes one pick (`max_picks=1`) and each tier
+   pickable carries the whole effect of being at that level. Picking a
+   tier replaces the one held (the picker's one-pick behaviour). The
+   card sub-row reads one name. §1's "one pick per rung, stacking" is
+   withdrawn. The credit figure stays on the Power Boost result.
+   Weapons only in this PR; a wargear's ladder still draws as its own
+   row under Gear until the gear line carries it. Decided by Tom 2026-09-09 after
    seeing PRs 1-3 on a local gang: the augmentation choice must sit on the
    weapon table under its weapon, as n23 prints "Augmentation: Tier 1"
    under the Bolt launcher row — display-only on the gang-sheet card, with

--- a/.claude/notes/issue-2313-plan.md
+++ b/.claude/notes/issue-2313-plan.md
@@ -336,9 +336,73 @@ test ends with `assert_reconciled(gang)`.
    result taken back drops its rating but not the spend. Stat limits
    (library 0093) now clamp a capped characteristic, so a wasted result
    reads as no change rather than a breach.
-4. **Clear glitches.** Route, dialog, the two tallies and the removals.
+4. **The tier draws under its weapon.** Decided by Tom 2026-09-09 after
+   seeing PRs 1-3 on a local gang: the augmentation choice must sit on the
+   weapon table under its weapon, as n23 prints "Augmentation: Tier 1"
+   under the Bolt launcher row — display-only on the gang-sheet card, with
+   controls on the model's edit page — and not as a choice line under
+   Gear. The plumbing already says which weapon: a slot built into a
+   weapon is materialised beside the model with `caused_by` the weapon's
+   assignment (`operations.py:1958-1966`), so its card node's
+   `caused_by_key` is the weapon node's key, and the choice's anchor is
+   that slot node (`effects.py:1703-1766`). The work:
+   - `WeaponLine.choices: list[ChoiceLine]` plus a `choices_have_actions`
+     property like `accessories_have_actions` (`render.py:321, 412`).
+   - In `card_to_model_card` (`render.py:1835-2240`): record the weapon
+     lines by node key at the two `weapon_line(...)` calls (`:2034,
+     :2037`); a `weapon_home(slot, weapons_by_key)` beside `question_row`
+     — true when `slot.anchor.key` or `slot.anchor.caused_by_key` is a
+     weapon's key — files the line on that weapon and keeps it out of
+     `choices` (`:2182-2187`, check before `question_row`).
+   - `ModelCard.questions` (`render.py:823-839`) must include weapon
+     choices, or `link_slots` (`views/choose.py:49-67`) never fills the
+     href and `printing.detail_groups` (`printing.py:97`) drops the row;
+     `n26/core/test_card_rows.py:80` guards this.
+   - Card template `cotton/n26/model_card/body.html`, after the
+     accessories block (`:315-350`): a `<tr><td colspan="99">` sub-row,
+     `pl-2`, reading "{kind_label}: {chosen}", "—" when nothing is picked.
+     Display-only by default; the Add/Choose link wrapped in
+     `<c-n26.model-card.mode when="edit">` as the Skills row does
+     (`body.html:69-112`). The model's edit page draws the card in edit
+     mode (`cotton/n26/view/model_edit.html:94`) and already links
+     weapon actions through `link_possession_actions`
+     (`views/owned.py:655-709`); the equip page is the catalogue and a
+     slot is `Family.CHOICE`, so it has no row there (`owned.py:316-386`).
+   - Phase A controls are links to the picker only. Inline "Add Tier 2"
+     / "Remove Tier 1" buttons need the next option key, which is
+     `build_choice_offer` → `offered_by` → one query per weapon choice
+     and would break the gang sheet's flat query budget
+     (`n26/tests/sandbox/test_render.py:217`); if wanted, phase B does it
+     on the single-model edit page only, reusing `choose()`'s
+     `thing=`/`remove=` POST with an `is_htmx` branch returning
+     `render_card_update` — `tally_counter` (`views/owned.py:1356`) plus
+     `counter_controls.html` is the precedent.
+   - Slot label: author it "Augmentation" (n23's stack name), not the
+     item's name — under the weapon the item is already said. The picker
+     page then names the weapon in its subtitle from the anchor's cause.
+   - No credit figure on the sub-row: n26 puts the money on the Power
+     Boost result, so a tier carries nothing to print. If Tom wants
+     "(+20¢)" beside the tier as n23 prints it, that reopens money on
+     the rung (§2, §4), and `WeaponLine.extras_rating` (`render.py:347`)
+     would have to fold it in or the figure would show while not being
+     counted.
+   - Print: append the picks to the weapon's `n26-print-subname` run
+     (`cotton/n26/print/weapons.html:54`) and drop them from
+     `printing.detail_groups` or they print twice. Text card
+     (`render_text.py:46-94`) moves them into the weapon block.
+   - Power Boost stays a row of its own under Gear: it is the model's
+     roll, not an item's.
+   - Tests: `test_card_rows.py`, `test_spyrer_augmentations.py` (the
+     ladder reads on `weapon.choices` and not in `card.choices`),
+     `test_render.py:217` budget, `test_printing.py`,
+     `test_views_owned.py`, `designsystem/sampledata.py:1386-1547` plus a
+     gallery demo (which fails silently — screenshot it).
+   - Known gap, pre-existing: a hire preview builds built-ins with
+     `caused_by_key=root.key` and never materialises a weapon's own
+     built-ins (`card.py:928-964`), so a preview shows no ladder.
+5. **Clear glitches.** Route, dialog, the two tallies and the removals.
    Tests: the count zeroes, the penalty picks go, the history reads.
-5. **Words and drawing.** The note on the augmentation choice, the Hunt
+6. **Words and drawing.** The note on the augmentation choice, the Hunt
    Master sentence, `recipes.md`, a gallery sample. Copywriter pass.
 
 A feature flag is probably unnecessary — nothing draws until the content
@@ -387,6 +451,4 @@ exists — but `n26/flags.py` is one line if 3 and 4 must land ahead of it.
    something for it?
 4. Which printing of the glitch table is canon, and is correcting the seeded
    one part of this issue?
-5. Should an item's augmentation choice draw under that item on the card, or
-   among the model's other choices? The second is free today; the first is a
-   change to `WeaponLine` (`n26/core/render.py:280-303`).
+5. *(Decided 2026-09-09: under the item, as n23 does — see §8 item 4.)*

--- a/n26/core/capture.py
+++ b/n26/core/capture.py
@@ -61,6 +61,7 @@ def _weapons(lines):
                 for profile in weapon.profiles
             ),
             tuple(sorted(a.name for a in weapon.accessories)),
+            tuple(_choices(weapon.choices)),
         )
         for weapon in lines
     )
@@ -97,7 +98,9 @@ def _model_state(card):
             (group.name, _rated(group.lines)) for group in card.gear_groups
         ],
         "collections": _names(card.collections),
-        "choices": _choices([*card.choices, *card.skill_choices, *card.power_choices]),
+        # The card's own rows; a question a weapon carries is captured with
+        # the weapon, where the page draws it.
+        "choices": _choices(card.row_questions),
         "remarks": _remarks(card.remarks),
         "xp": card.xp,
         "xp_target": card.xp_target,

--- a/n26/core/printing.py
+++ b/n26/core/printing.py
@@ -94,9 +94,10 @@ def detail_groups(card) -> list[DetailGroup]:
                 gear_group.name, ", ".join(line.name for line in gear_group.lines)
             )
         )
-    for choice in card.questions:
+    for choice in card.row_questions:
         # What it holds, or a blank. The Add on the screen card is a way
-        # into the picker, and nothing on paper can be added.
+        # into the picker, and nothing on paper can be added. A question
+        # a weapon carries prints beside the weapon instead.
         groups.append(DetailGroup(choice.kind_label, choice.chosen or "—"))
     for effect in card.effects:
         # "(when taken)" on paper as on screen. A printed card is read away

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -351,13 +351,6 @@ class WeaponLine:
     choices: list[ChoiceLine] = field(default_factory=list)
 
     @property
-    def choices_have_actions(self):
-        """Whether any of the weapon's choices leads somewhere. Only a
-        card drawn for the owner's own page links them; the gang sheet
-        and the print sheet draw the level as a fact."""
-        return any(choice.href for choice in self.choices)
-
-    @property
     def extras_rating(self):
         """What rides on the weapon: its paid profiles and its accessories.
 
@@ -1593,6 +1586,12 @@ def question_row(slot):
     return row if row in ModelCard.QUESTION_BUCKETS else None
 
 
+def id_of(slot):
+    """What tells one computed question from another while a card is
+    built: the object itself. Computed rows carry no key of their own."""
+    return id(slot)
+
+
 def weapon_home(slot, weapons_by_key):
     """The weapon line a question is drawn under, or None for a row of the
     card's own.
@@ -2077,8 +2076,13 @@ def card_to_model_card(
                 AssignableLine(name=node.name, provenance=provenance_of(node))
             )
         elif isinstance(thing, Weapon):
-            weapons_by_key[node.key] = weapon_line(node, node.children)
-            weapons.append(weapons_by_key[node.key])
+            line = weapon_line(node, node.children)
+            weapons.append(line)
+            # A part bolted onto the weapon — a sight with a ladder of its
+            # own — hangs off it, so a choice the part brought is drawn
+            # under the weapon too.
+            for key in (node.key, *(child.key for child in node.children)):
+                weapons_by_key[key] = line
         elif isinstance(thing, WeaponProfile):
             # A profile assigned straight to the model rather than to a weapon.
             weapons_by_key[node.key] = weapon_line(node, [node])
@@ -2178,10 +2182,18 @@ def card_to_model_card(
                 counted_xp = standing
 
     vehicle = primary is not None and primary.profile_type.name == "Vehicle"
+    # A question a weapon brought is drawn under the weapon and nowhere
+    # else — unless a named row takes it, as a skill offer a weapon makes
+    # still belongs in the Skills row. Decided once per question here;
+    # the rows below leave out what was filed.
+    weapon_hosted = set()
     for slot in computed.choices if computed else []:
+        if question_row(slot) is not None:
+            continue
         home = weapon_home(slot, weapons_by_key)
         if home is not None:
             home.choices.append(_choice_line(slot, id))
+            weapon_hosted.add(id_of(slot))
 
     return ModelCard(
         name=name,
@@ -2236,8 +2248,7 @@ def card_to_model_card(
             *(
                 _choice_line(slot, id)
                 for slot in (computed.choices if computed else [])
-                if question_row(slot) is None
-                and weapon_home(slot, weapons_by_key) is None
+                if question_row(slot) is None and id_of(slot) not in weapon_hosted
             ),
             # What the gang picked, where a modifier says this model's
             # card draws it. After the card's own questions: they are

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -343,6 +343,19 @@ class WeaponLine:
     #: weapon has one; it stays off ``more`` because it adds something
     #: rather than taking it away.
     accessorise: object = None
+    #: The choices this weapon brought with it — an augmentation ladder
+    #: built into a Spyrer's launchers. Drawn under the weapon, as the
+    #: book prints a tier beside the item it is on, and not among the
+    #: card's own rows. Each holds one pick at most: an item is at one
+    #: level.
+    choices: list[ChoiceLine] = field(default_factory=list)
+
+    @property
+    def choices_have_actions(self):
+        """Whether any of the weapon's choices leads somewhere. Only a
+        card drawn for the owner's own page links them; the gang sheet
+        and the print sheet draw the level as a fact."""
+        return any(choice.href for choice in self.choices)
 
     @property
     def extras_rating(self):
@@ -836,7 +849,18 @@ class ModelCard:
         these into controls reads the address on the line rather than
         assuming one.
         """
+        return [*self.row_questions, *self.weapon_questions]
+
+    @property
+    def row_questions(self):
+        """The questions drawn as rows of the card — every question but
+        the ones an item carries under itself."""
         return [*self.choices, *self.skill_choices, *self.power_choices]
+
+    @property
+    def weapon_questions(self):
+        """The questions drawn under a weapon: what its own choices ask."""
+        return [choice for weapon in self.weapons for choice in weapon.choices]
 
     @property
     def weapon_columns(self):
@@ -1569,6 +1593,25 @@ def question_row(slot):
     return row if row in ModelCard.QUESTION_BUCKETS else None
 
 
+def weapon_home(slot, weapons_by_key):
+    """The weapon line a question is drawn under, or None for a row of the
+    card's own.
+
+    A slot built into a weapon is materialised beside the model and
+    caused by the weapon's assignment, so the slot node's cause is the
+    weapon's key; an offer a weapon's own modifier makes anchors on the
+    weapon itself. Either way the question belongs to that weapon, and a
+    card draws it there — the tier beside the launchers it is on — rather
+    than as a row about the model.
+    """
+    anchor = slot.anchor
+    if anchor is None:
+        return None
+    return weapons_by_key.get(anchor.key) or weapons_by_key.get(
+        getattr(anchor, "caused_by_key", None)
+    )
+
+
 def choice_lines(computed, host=""):
     """A computed card's choice slots as lines a renderer draws.
 
@@ -1864,6 +1907,9 @@ def card_to_model_card(
     """
     primary = None
     equipment, weapons = [], []
+    #: Weapon lines by their node's key, so a question a weapon brought
+    #: can be filed under it.
+    weapons_by_key = {}
     #: Lines diverted out of Gear, by the category that asked for them.
     #: Keyed by category pk, holding the category itself so the groups
     #: can be put in the taxonomy's order once the walk is done.
@@ -2031,10 +2077,12 @@ def card_to_model_card(
                 AssignableLine(name=node.name, provenance=provenance_of(node))
             )
         elif isinstance(thing, Weapon):
-            weapons.append(weapon_line(node, node.children))
+            weapons_by_key[node.key] = weapon_line(node, node.children)
+            weapons.append(weapons_by_key[node.key])
         elif isinstance(thing, WeaponProfile):
             # A profile assigned straight to the model rather than to a weapon.
-            weapons.append(weapon_line(node, [node]))
+            weapons_by_key[node.key] = weapon_line(node, [node])
+            weapons.append(weapons_by_key[node.key])
         elif isinstance(thing, Counter):
             # A counter is a running number, not a possession, so it is
             # never drawn as a piece of kit: it draws a line of its own.
@@ -2130,6 +2178,11 @@ def card_to_model_card(
                 counted_xp = standing
 
     vehicle = primary is not None and primary.profile_type.name == "Vehicle"
+    for slot in computed.choices if computed else []:
+        home = weapon_home(slot, weapons_by_key)
+        if home is not None:
+            home.choices.append(_choice_line(slot, id))
+
     return ModelCard(
         name=name,
         id=id,
@@ -2184,6 +2237,7 @@ def card_to_model_card(
                 _choice_line(slot, id)
                 for slot in (computed.choices if computed else [])
                 if question_row(slot) is None
+                and weapon_home(slot, weapons_by_key) is None
             ),
             # What the gang picked, where a modifier says this model's
             # card draws it. After the card's own questions: they are

--- a/n26/core/render_text.py
+++ b/n26/core/render_text.py
@@ -72,14 +72,13 @@ def render_model_card(card, indent=""):
             lines.append(f"{indent}    {label}")
             for accessory in weapon.accessories:
                 lines.append(f"{indent}      + {accessory.name}")
-            for choice in weapon.choices:
-                lines.append(
-                    f"{indent}      {choice.kind_label}: {choice.chosen or '—'}"
-                )
             for profile in weapon.named_profiles:
                 lines.append(
                     f"{indent}      - {profile.name}{_profile_suffix(profile)}"
                 )
+            for choice in weapon.choices:
+                chosen = choice.chosen if choice.is_resolved else "— (not chosen)"
+                lines.append(f"{indent}      {choice.kind_label}: {chosen}")
     if card.skills:
         names = ", ".join(line.name for line in card.skills)
         lines.append(f"{indent}  Skills: {names}")

--- a/n26/core/render_text.py
+++ b/n26/core/render_text.py
@@ -72,6 +72,10 @@ def render_model_card(card, indent=""):
             lines.append(f"{indent}    {label}")
             for accessory in weapon.accessories:
                 lines.append(f"{indent}      + {accessory.name}")
+            for choice in weapon.choices:
+                lines.append(
+                    f"{indent}      {choice.kind_label}: {choice.chosen or '—'}"
+                )
             for profile in weapon.named_profiles:
                 lines.append(
                     f"{indent}      - {profile.name}{_profile_suffix(profile)}"
@@ -85,7 +89,7 @@ def render_model_card(card, indent=""):
     if card.powers:
         names = ", ".join(line.name for line in card.powers)
         lines.append(f"{indent}  Powers: {names}")
-    for choice in card.questions:
+    for choice in card.row_questions:
         # Drawn like any other assignable's row; a real UI hangs the picker
         # link here. The provenance is deliberately not shown.
         chosen = choice.chosen if choice.is_resolved else "— (not chosen)"

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -348,6 +348,30 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                                 </td>
                             </tr>
                         {% endif %}
+                        {% comment %}
+                        A choice the weapon brought — its augmentation level —
+                        is drawn under the weapon, as the book prints the tier
+                        beside the item. The gang sheet states the level; only
+                        the model's own page offers a way to change it.
+                        {% endcomment %}
+                        {% if weapon.choices %}
+                            <tr>
+                                <td colspan="99" class="px-4 pb-2 text-ink-900 dark:text-ink-100">
+                                    <ul class="flex flex-col gap-1 pl-2">
+                                        {% for choice in weapon.choices %}
+                                            <li class="flex items-center gap-2">
+                                                <span class="min-w-0">{{ choice.kind_label }}: {% if choice.is_resolved %}{{ choice.chosen }}{% else %}&mdash;{% endif %}</span>
+                                                <c-n26.model-card.mode when="edit">
+                                                    {% if choice.href %}
+                                                        <c-n26.link href="{{ choice.href }}" underline="always" class="text-xs">{% if choice.is_resolved %}Change{% else %}Choose{% endif %}</c-n26.link>
+                                                    {% endif %}
+                                                </c-n26.model-card.mode>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </td>
+                            </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>

--- a/n26/core/templates/cotton/n26/print/weapons.html
+++ b/n26/core/templates/cotton/n26/print/weapons.html
@@ -51,7 +51,7 @@ want.
                 combi-weapon has an unnamed profile with no characteristics of
                 its own.
                     {% endcomment %}
-                    <td {% if not stats %}colspan="{{ card.weapon_columns|length|add:1 }}"{% endif %}>{{ weapon.name }}{% if weapon.accessories %} <span class="n26-print-subname">{% for accessory in weapon.accessories %}+ {{ accessory.name }}{% if not forloop.last %} {% endif %}{% endfor %}</span>{% endif %}{% if weapon.choices %} <span class="n26-print-subname">{% for choice in weapon.choices %}{{ choice.kind_label }}: {{ choice.chosen|default:"—" }}{% if not forloop.last %}; {% endif %}{% endfor %}</span>{% endif %}</td>
+                    <td {% if not stats %}colspan="{{ card.weapon_columns|length|add:1 }}"{% endif %}>{{ weapon.name }}{% if weapon.accessories or weapon.choices %} <span class="n26-print-subname">{% for accessory in weapon.accessories %}+ {{ accessory.name }}{% if not forloop.last or weapon.choices %}; {% endif %}{% endfor %}{% for choice in weapon.choices %}{{ choice.kind_label }}: {{ choice.chosen|default:"—" }}{% if not forloop.last %}; {% endif %}{% endfor %}</span>{% endif %}</td>
                     {% if stats %}
                         {% for cell in stats %}
                             <td class="is-centered{% if cell.first_of_group %} is-group{% endif %}">{{ cell.value|default:"-" }}</td>

--- a/n26/core/templates/cotton/n26/print/weapons.html
+++ b/n26/core/templates/cotton/n26/print/weapons.html
@@ -51,7 +51,7 @@ want.
                 combi-weapon has an unnamed profile with no characteristics of
                 its own.
                     {% endcomment %}
-                    <td {% if not stats %}colspan="{{ card.weapon_columns|length|add:1 }}"{% endif %}>{{ weapon.name }}{% if weapon.accessories %} <span class="n26-print-subname">{% for accessory in weapon.accessories %}+ {{ accessory.name }}{% if not forloop.last %} {% endif %}{% endfor %}</span>{% endif %}</td>
+                    <td {% if not stats %}colspan="{{ card.weapon_columns|length|add:1 }}"{% endif %}>{{ weapon.name }}{% if weapon.accessories %} <span class="n26-print-subname">{% for accessory in weapon.accessories %}+ {{ accessory.name }}{% if not forloop.last %} {% endif %}{% endfor %}</span>{% endif %}{% if weapon.choices %} <span class="n26-print-subname">{% for choice in weapon.choices %}{{ choice.kind_label }}: {{ choice.chosen|default:"—" }}{% if not forloop.last %}; {% endif %}{% endfor %}</span>{% endif %}</td>
                     {% if stats %}
                         {% for cell in stats %}
                             <td class="is-centered{% if cell.first_of_group %} is-group{% endif %}">{{ cell.value|default:"-" }}</td>

--- a/n26/core/templates/n26/choose.html
+++ b/n26/core/templates/n26/choose.html
@@ -54,6 +54,10 @@ survives a reload and can be linked to; nothing is rolled by drawing.
         names one card's carrier and one offer, so there is no such page for
         anybody else; the kit screen is the fighter page they all have.
         {% endcomment %}
+        {% if returning %}
+            {# The screen this page was opened from, carried through the post so the reader lands back on it. #}
+            <input type="hidden" name="return" value="{{ returning }}">
+        {% endif %}
         {% if miniature %}
             <c-slot name="trailing">
                 {% fighter_switcher gang miniature as fighter_switcher_ %}

--- a/n26/core/test_card_rows.py
+++ b/n26/core/test_card_rows.py
@@ -77,6 +77,33 @@ class TestTheCardRows:
                 f"card. Give the row the Choose treatment the Skills row has."
             )
 
+    def test_a_question_a_weapon_carries_is_linked_and_drawn(self):
+        """An item's own choice draws under the item, so it is not in any
+        bucket — and it still has to reach the picker and the template."""
+        from n26.core.render import ChoiceLine, Statline, WeaponLine
+        from n26.core.views.choose import link_slots
+
+        card = ModelCard(
+            name="Nobody",
+            rating=0,
+            statline=Statline(),
+            weapons=[
+                WeaponLine(
+                    name="Gun",
+                    base_rating=0,
+                    choices=[
+                        ChoiceLine(kind_label="Augmentation", chosen=None, key="a:b:1")
+                    ],
+                )
+            ],
+        )
+        assert card.questions == card.weapons[0].choices
+        assert card.row_questions == []
+        link_slots(SimpleNamespace(pk="a-gang"), card)
+        assert card.weapons[0].choices[0].href
+        template = "".join(t.read_text() for t in CARD_TEMPLATES)
+        assert "weapon.choices" in template
+
     def test_every_question_row_is_pointed_at_its_picker(self):
         """Drawn is not enough. A question carries its address and a view
         turns it into a URL, so a bucket nothing links draws a control with

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -541,6 +541,10 @@ def _item_behind(found):
     the item's assignment."""
     from n26.library.models import Wargear, Weapon, WeaponAccessory
 
+    if found.slot.slot is None:
+        # An offer's cause is whatever brought the offerer, not an item
+        # the choice is about.
+        return None
     cause = getattr(found.anchor, "caused_by", None)
     if cause is None:
         return None

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -30,6 +30,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
+from n26.core.owned import with_query
 from n26.core.views.permissions import _own_gang_or_404
 from n26.library.staged import sees_staged
 
@@ -46,13 +47,19 @@ class _Found:
     miniature: object = None
 
 
-def link_slots(gang, *holders):
+def link_slots(gang, *holders, back=""):
     """Point every choice slot on these structures at its picker.
 
     Costs no queries: a slot's address is already on the line, and this
     only turns it into a URL. A slot with no address keeps an empty href
     and draws as a fact with nothing to click — which is right for a card
     depicting nobody.
+
+    ``back`` is the screen the card is drawn on, carried on every link
+    so the picker returns the reader there once the choice is settled
+    rather than to the gang. Passed rather than read off a request, as
+    ``link_counters`` has it: a card redrawn after an act is rendered
+    under that act's own address.
 
     A card files some of its questions into rows of their own — the ones
     drawn beside the skills and the powers the model already has — so what
@@ -61,10 +68,14 @@ def link_slots(gang, *holders):
     every one of them is chosen for at the same address, and a holder that
     grows another row is linked by the same line.
     """
+    from n26.core.owned import with_query
+
     for holder in holders:
         for line in holder.questions:
             if line.key:
                 line.href = reverse("n26-choose", args=[gang.pk, line.key])
+                if back:
+                    line.href = with_query(line.href, **{"return": back})
 
 
 def _find_slot(gang, key):
@@ -311,8 +322,15 @@ def choose(request, pk, slot):
     # roll panel are read against the same list.
     shown = sees_staged(request.user)
     offer = build_choice_offer(found.slot, found.computed, include_staged=shown)
-    back = reverse("n26-gang", args=[gang.pk])
+    # Where the reader came from, forwarded by the link that opened this
+    # page and carried through the form, so settling the choice lands
+    # them back on the screen they were reading. Only this site's own
+    # addresses are honoured; anything else falls back to the gang.
+    returning = request.POST.get("return") or request.GET.get("return", "")
+    back = _own_address(request, returning) or reverse("n26-gang", args=[gang.pk])
     here = reverse("n26-choose", args=[gang.pk, slot])
+    if returning:
+        here = with_query(here, **{"return": returning})
 
     if request.method == "POST" and request.POST.get("act") in {"roll", "enter"}:
         # Rolling writes before anything is picked: the roll is on the
@@ -355,7 +373,7 @@ def choose(request, pk, slot):
             action="roll",
             entered=rolled is not None,
         )
-        return redirect(f"{here}?roll={event.pk}")
+        return redirect(with_query(here, roll=event.pk))
 
     if request.method == "POST":
         dropped = request.POST.get("remove", "")
@@ -529,8 +547,23 @@ def choose(request, pk, slot):
             # footer's columns have one — draws whatever the page happens
             # to have under it.
             "pick_lead": f"{item}, for {bearer}." if item else f"For {bearer}.",
+            "returning": returning,
         },
     )
+
+
+def _own_address(request, url):
+    """``url`` if it is one of this site's own pages, else an empty string.
+
+    A return address arrives in the query and the form, so it is checked
+    against this request's host before anything redirects to it."""
+    from django.utils.http import url_has_allowed_host_and_scheme
+
+    if url and url_has_allowed_host_and_scheme(
+        url, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        return url
+    return ""
 
 
 def _item_behind(found):

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -506,6 +506,7 @@ def choose(request, pk, slot):
             offer = lift_landing(offer, landed, threshold=roll.threshold)
 
     bearer = found.miniature.name if found.miniature is not None else gang.name
+    item = _item_behind(found)
     return render(
         request,
         "n26/choose.html",
@@ -527,6 +528,23 @@ def choose(request, pk, slot):
             # component on the page with a slot of that name — the site
             # footer's columns have one — draws whatever the page happens
             # to have under it.
-            "pick_lead": f"For {bearer}.",
+            "pick_lead": f"{item}, for {bearer}." if item else f"For {bearer}.",
         },
     )
+
+
+def _item_behind(found):
+    """The piece of kit whose own choice this is — the launchers an
+    augmentation ladder is built into — or None for a choice the model
+    or the gang carries itself. Read off the slot's cause: a choice
+    built into an item is materialised beside the model and caused by
+    the item's assignment."""
+    from n26.library.models import Wargear, Weapon, WeaponAccessory
+
+    cause = getattr(found.anchor, "caused_by", None)
+    if cause is None:
+        return None
+    thing = cause.assignable
+    if isinstance(thing, (Weapon, Wargear, WeaponAccessory)):
+        return str(thing)
+    return None

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -300,7 +300,7 @@ def render_card_update(request, miniature, at):
     index = build_modifier_index(carriers(own))
     computed = compute(own, index)
     card = build_model_card(miniature, card=own, computed=computed)
-    link_slots(gang, card)
+    link_slots(gang, card, back=at)
     link_skills(card, among=model_collections())
     link_counters(card, back=at)
     # The card is drawn in edit mode, and edit mode's card carries the
@@ -672,7 +672,7 @@ def edit_fighter(request, pk):
     # the roster tally below. The card's own build carries the gang's
     # assignments already, so what the gang grants still reaches it.
     card = build_model_card(miniature, card=own, computed=computed)
-    link_slots(gang, card)
+    link_slots(gang, card, back=request.get_full_path())
     link_skills(card, among=sets)
     # Only here. A counter is drawn wherever a card is; the model's own
     # page is the one place it is moved, so this is the one place the

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1437,6 +1437,19 @@ def model_card():
                 # is the whole point of the accessory scope: "the weapon I am
                 # attached to". A card has to be able to say which weapon.
                 accessories=[AssignableLine(name="Telescopic sight")],
+                # A choice the weapon itself brought: an augmentation ladder at
+                # its second level. Drawn under the weapon, never as a row of
+                # the card's own.
+                choices=[
+                    ChoiceLine(
+                        kind_label="Augmentation",
+                        chosen="Tier 2",
+                        key="vesna-krail:lasgun:augmentation",
+                        provenance=Provenance(
+                            source="Lasgun", source_kind="weapon", computed=True
+                        ),
+                    )
+                ],
             ),
             WeaponLine(
                 # Two profiles, both free, neither named after the weapon — so the
@@ -2169,6 +2182,7 @@ def model_card_editable():
         weapon.sell = sell
         weapon.more = more
         weapon.accessorise = accessorise
+        weapon.choices = [replace(choice, href="#") for choice in weapon.choices]
         weapon.accessories = [
             replace(line, sell=sell, more=part_more) for line in weapon.accessories
         ]

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -385,6 +385,49 @@ page. The reverse is a valid setup rather than a mistake: place the
 family and offer nothing, and the model may select powers from it at any
 time but is not given a first one.
 
+## An item's augmentation tiers
+
+> Draft, for review.
+
+The book prints augmentation tiers for each of a Spyrer's weapons and
+for the hunting rig. An item has one augmentation level. Suit Evolution
+raises it by one, a glitch can lower it by one, and each level carries
+the changes of every level below it. The level shows under the item on
+the model's card.
+
+1. Create a **slot type** named "Augmentation", plural "Augmentations",
+   with *allows repeats* off. One slot type serves every item.
+2. For each item, add a **pickable** per tier — "Tier 1", "Tier 2",
+   "Tier 3" — with the item's name as the qualifier, so each item has
+   tiers of its own. Players never see the qualifier.
+3. On each tier's page, attach the **modifiers** that apply at that
+   level. Tier 2 carries Tier 1's modifiers as well as its own, and
+   Tier 3 carries the modifiers of all three. A weapon's modifier
+   targets *weapons named* that weapon: set Lethality to 2, set Armour
+   Piercing to -2. A rig's modifier targets *the model*: improve
+   Strength by 1. Swapping a trait takes two modifiers: one that takes
+   the old trait away, one that gives the new. Where a later tier
+   changes what an earlier tier changed — a 6+ field save at Tier 1
+   and a 5+ field save at Tier 3 — the later tier carries the later
+   value only. Nothing from Tier 1 is in play once Tier 3 is picked.
+4. Add a **picklist** of that item's tiers, in order.
+5. Add a **slot** on that picklist, labelled "Augmentation", taking 0 to
+   1 picks, assigned to the bearer.
+6. Build the slot into the item. The card of a model carrying the item
+   then draws an "Augmentation" line under the item, holding the tier
+   picked or a dash.
+
+Picking a tier replaces the one held. The player picks the next tier
+after a Hunting Rig Augmentation result, and the tier below after a
+System Downgrade glitch. Every tier is offered whatever the level, so a
+player who reads the book differently is not stopped. Tiers carry no
+price and add nothing to the rating: the credits sit on the Power Boost
+result that raised the level.
+
+A rig's tiers are not yet drawn under the rig: they show as a line of
+their own under Gear, because only a weapon draws its tiers under the
+item itself.
+
 ## Suit Evolution: the Power Boost table
 
 > Draft, for review.

--- a/n26/tests/sandbox/test_spyrer_augmentations.py
+++ b/n26/tests/sandbox/test_spyrer_augmentations.py
@@ -1,19 +1,21 @@
-"""Spyrer suit augmentations: a tier ladder built from slots and picks.
+"""Spyrer suit augmentations: an item's level, built from a slot and picks.
 
 Every item a Spyrer carries prints its own augmentation tiers — a bolt
 launcher's Tier 1 raises its Lethality, Tier 2 its Armour Piercing, Tier 3
 swaps Rapid Fire (1) for Rapid Fire (2); a Jakara hunting rig's tiers
-raise the wearer's Strength and then Attacks. Tiers are gained one at a
-time through Suit Evolution and stack: an item at Tier 2 has both its
-first and second tier working.
+raise the wearer's Strength and then Attacks. An item has one augmentation
+level, which Suit Evolution raises by one and a glitch can lower by one,
+and a higher level keeps what the lower ones brought online.
 
 This file states that the ladder is content, not code. Per item: one
 picklist of an **Augmentation** slot type holding that item's tiers as
-pickables, and one slot built into the item, so the choice appears on
-whoever carries it and goes when the item goes. A level is one pick per
-rung, and the level is the count of live picks — never stored. Each tier
-carries its effect as ordinary modifiers that name the item outright
-(``targets_weapons(is_one_of(...))``) or reach the wearer
+pickables, and one slot of a single pick built into the item, so the
+choice appears on whoever carries it and goes when the item goes. The
+level is the pick; each tier carries the whole effect of being at that
+level, so Tier 2's modifiers restate Tier 1's — as the book's own
+wording of "additional functions online" wants, and as the earlier
+edition's content is written. Each modifier names the item outright
+(``targets_weapons(is_one_of(...))``) or reaches the wearer
 (``targets_model()``); a trait swap is a removal and an addition.
 
 Rungs are free. What raises the Spyrer's credit value is the Power Boost
@@ -21,6 +23,9 @@ result that unlocked the tier, which is a pick of its own on the model.
 So climbing, stepping back and switching move no credits and no rating
 here, which is what lets a player change their mind: the app informs,
 it does not police.
+
+The choice draws under the weapon it belongs to, as the book prints the
+tier beside the item, and never as a row about the model.
 
 The Orrus carries two bolt launchers, printed as one line ("x2"), and the
 book's augmentation is of the pair. They are one weapon here for the same
@@ -48,6 +53,7 @@ from n26.tests.sandbox.actions import (
     create_pickable,
     create_picklist,
     create_profile,
+    create_rule,
     create_slot,
     create_slot_type,
     create_stat,
@@ -115,8 +121,7 @@ def gang(owner, gang_type):
 
 @pytest.fixture
 def augmentation(default_pack):
-    """The slot type. Each tier is its own pickable, so repeats are never
-    wanted: Tier 1 is taken once."""
+    """The slot type. One level per item, so a choice of it takes one pick."""
     return create_slot_type(
         "Augmentation", plural_name="Augmentations", allows_repeats=False
     )
@@ -164,33 +169,37 @@ def bolt_launchers(weapon_statline_type, traits):
 def bolt_launcher_tiers(
     bolt_launchers, augmentation, lethality, armour_piercing, traits
 ):
-    """Three rungs, each naming the launchers outright. The third is a
-    swap, so it is two modifiers: take Rapid Fire (1) off, put Rapid
-    Fire (2) on. A scope belongs to one modifier, so each gets its own."""
+    """Three levels, each naming the launchers outright and each carrying
+    the whole of being at that level: Tier 2 restates Tier 1's change,
+    Tier 3 restates both and swaps the trait. A scope belongs to one
+    modifier, so each gets its own."""
 
     def launchers():
         return targets_weapons(is_one_of(bolt_launchers))
 
+    def lethal():
+        return (launchers(), changes_stat(lethality, mode="set", amount=2))
+
+    def piercing():
+        return (launchers(), changes_stat(armour_piercing, mode="set", amount=-2))
+
     tiers = {
         "Tier 1": create_pickable(
-            "Tier 1",
-            augmentation,
-            qualifier="Bolt launchers",
-            effects=[(launchers(), changes_stat(lethality, mode="set", amount=2))],
+            "Tier 1", augmentation, qualifier="Bolt launchers", effects=[lethal()]
         ),
         "Tier 2": create_pickable(
             "Tier 2",
             augmentation,
             qualifier="Bolt launchers",
-            effects=[
-                (launchers(), changes_stat(armour_piercing, mode="set", amount=-2))
-            ],
+            effects=[lethal(), piercing()],
         ),
         "Tier 3": create_pickable(
             "Tier 3",
             augmentation,
             qualifier="Bolt launchers",
             effects=[
+                lethal(),
+                piercing(),
                 (launchers(), adds(traits["Rapid Fire (2)"])),
                 (launchers(), removes(traits["Rapid Fire (1)"])),
             ],
@@ -203,9 +212,9 @@ def bolt_launcher_tiers(
         "Bolt launchers augmentation",
         augmentation,
         table,
-        label="Bolt launchers",
+        label="Augmentation",
         min_picks=0,
-        max_picks=3,
+        max_picks=1,
     )
     add_built_in(bolt_launchers, slot)
     return tiers
@@ -215,28 +224,31 @@ def bolt_launcher_tiers(
 def jakara_rig(augmentation, fighter_stats):
     """Wargear whose tiers reach the wearer rather than a weapon."""
     rig = create_wargear("Jakara hunting rig", price=0)
+
+    def strength():
+        return (
+            targets_model(),
+            changes_stat(fighter_stats["S"], mode="improve", amount=1),
+        )
+
+    def attacks():
+        return (
+            targets_model(),
+            changes_stat(fighter_stats["A"], mode="improve", amount=1),
+        )
+
     tiers = {
         "Tier 1": create_pickable(
             "Tier 1",
             augmentation,
             qualifier="Jakara hunting rig",
-            effects=[
-                (
-                    targets_model(),
-                    changes_stat(fighter_stats["S"], mode="improve", amount=1),
-                )
-            ],
+            effects=[strength()],
         ),
         "Tier 2": create_pickable(
             "Tier 2",
             augmentation,
             qualifier="Jakara hunting rig",
-            effects=[
-                (
-                    targets_model(),
-                    changes_stat(fighter_stats["A"], mode="improve", amount=1),
-                )
-            ],
+            effects=[strength(), attacks()],
         ),
     }
     table = create_picklist(
@@ -246,9 +258,9 @@ def jakara_rig(augmentation, fighter_stats):
         "Jakara hunting rig augmentation",
         augmentation,
         table,
-        label="Jakara hunting rig",
+        label="Augmentation",
         min_picks=0,
-        max_picks=2,
+        max_picks=1,
     )
     add_built_in(rig, slot)
     return rig, tiers
@@ -310,26 +322,50 @@ def traits_of(weapon):
     return [trait.name for trait in weapon.profiles[0].traits]
 
 
-def ladder_of(miniature, label):
-    """The computed choice for one item's augmentations."""
+def choice_behind(miniature, item):
+    """The computed choice an item carries: the one whose anchor the
+    item's assignment caused."""
     _, computed = card_for(miniature)
-    return next(line for line in computed.choices if line.kind_label == label)
+    return next(
+        line for line in computed.choices if line.anchor.caused_by_key == item.pk
+    )
 
 
-def climb(miniature, label, tier):
-    return choose(ladder_of(miniature, label).anchor.assignment, tier)
+def ladder_of(miniature, weapon_name):
+    weapon = Assignment.objects.get(
+        miniature=miniature, weapon__name=weapon_name, archived=False
+    )
+    return choice_behind(miniature, weapon)
+
+
+def set_level(ladder, tier):
+    """Take a tier on a one-pick choice, as the picker does: the pick
+    held is taken back and the new one written. The verb alone writes a
+    pick; replacing the standing one is the page's act."""
+    for pick in ladder.picks:
+        remove(pick.assignment)
+    return choose(ladder.anchor.assignment, tier)
+
+
+def climb(miniature, weapon_name, tier):
+    return set_level(ladder_of(miniature, weapon_name), tier)
 
 
 class TestTheLadderArrivesWithTheItem:
     """Carrying an augmentable item opens its augmentation choice on the
-    carrier's card. Nothing is written for the rungs: the line is
-    computed, empty, and asks for nothing."""
+    carrier's card, drawn under the item. Nothing is written for the
+    level: the line is computed, empty, and asks for nothing."""
 
-    def test_the_launchers_bring_an_open_choice(self, orrus, gang):
-        ladder = ladder_of(orrus, "Bolt launchers")
+    def test_the_launchers_bring_an_open_choice_under_the_weapon(self, orrus, gang):
+        drawn, _ = card_for(orrus)
+        gun = next(w for w in drawn.weapons if w.name == "Bolt launchers")
 
-        assert not ladder.is_resolved
-        assert (ladder.min_picks, ladder.max_picks) == (0, 3)
+        (choice,) = gun.choices
+        assert choice.kind_label == "Augmentation"
+        assert not choice.is_resolved
+        assert not choice.takes_several
+        assert [line.kind_label for line in drawn.choices] == []
+        assert drawn.questions == gun.choices
         assert_reconciled(gang)
 
     def test_a_model_without_the_item_has_no_ladder(
@@ -337,8 +373,8 @@ class TestTheLadderArrivesWithTheItem:
     ):
         unarmed = hire(gang, spyrer, "Kaustos", paid=200)
 
-        _, computed = card_for(unarmed)
-        assert [line.kind_label for line in computed.choices] == []
+        drawn, _ = card_for(unarmed)
+        assert drawn.questions == []
         assert_reconciled(gang)
 
     def test_an_empty_ladder_leaves_no_remark(self, orrus):
@@ -348,8 +384,9 @@ class TestTheLadderArrivesWithTheItem:
 
 
 class TestClimbingTheLadder:
-    """Each rung is a pick, and the picks stack: the level is how many
-    the model holds. Every tier's effect lands on the launchers and on
+    """The level is one pick. Picking the next tier replaces the one held,
+    and a tier carries everything below it, so the card at Tier 2 shows
+    both changes. Every tier's effect lands on the launchers and on
     nothing else the Spyrer carries."""
 
     def test_tier_one_raises_lethality_and_nothing_else(
@@ -361,27 +398,32 @@ class TestClimbingTheLadder:
         assert stat_of(gun, "L") == "2"
         assert stat_of(gun, "AP") == "-1"
         assert traits_of(gun) == ["Rapid Fire (1)", "Sidearm"]
+        assert [choice.chosen for choice in gun.choices] == ["Tier 1"]
         assert_reconciled(gang)
 
-    def test_tier_two_stacks_on_tier_one(self, gang, orrus, bolt_launcher_tiers):
+    def test_tier_two_replaces_tier_one_and_keeps_its_change(
+        self, gang, orrus, bolt_launcher_tiers
+    ):
         climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 1"])
         climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 2"])
 
         gun = gun_of(orrus, "Bolt launchers")
         assert stat_of(gun, "L") == "2"
         assert stat_of(gun, "AP") == "-2"
-        ladder = ladder_of(orrus, "Bolt launchers")
-        assert len(ladder.picks) == 2
-        assert ladder.chosen_name == "Tier 1, Tier 2"
+        assert [choice.chosen for choice in gun.choices] == ["Tier 2"]
+        assert not Assignment.objects.filter(
+            pickable=bolt_launcher_tiers["Tier 1"], archived=False
+        ).exists()
         assert_reconciled(gang)
 
     def test_tier_three_swaps_the_trait(self, gang, orrus, bolt_launcher_tiers):
-        for tier in ("Tier 1", "Tier 2", "Tier 3"):
-            climb(orrus, "Bolt launchers", bolt_launcher_tiers[tier])
+        climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 3"])
 
         gun = gun_of(orrus, "Bolt launchers")
+        assert stat_of(gun, "L") == "2"
+        assert stat_of(gun, "AP") == "-2"
         assert traits_of(gun) == ["Rapid Fire (2)", "Sidearm"]
-        assert ladder_of(orrus, "Bolt launchers").is_full
+        assert gun.choices[0].is_full
         assert_reconciled(gang)
 
     def test_the_rigs_tiers_reach_the_wearer(self, gang, orrus, jakara_rig):
@@ -390,8 +432,8 @@ class TestClimbingTheLadder:
         drawn, _ = card_for(orrus)
         assert drawn.statline.get("S").value == "3"
 
-        climb(orrus, "Jakara hunting rig", tiers["Tier 1"])
-        climb(orrus, "Jakara hunting rig", tiers["Tier 2"])
+        worn = Assignment.objects.get(miniature=orrus, wargear=rig, archived=False)
+        set_level(choice_behind(orrus, worn), tiers["Tier 2"])
 
         drawn, _ = card_for(orrus)
         assert drawn.statline.get("S").value == "4"
@@ -416,8 +458,8 @@ class TestClimbingTheLadder:
 
 class TestTheLadderIsTheModelsOwn:
     """A tier is a pick on one model, about that model's item. Another
-    Spyrer's launchers are untouched, the picks go with the item, and a
-    step back is an ordinary removal that owes nobody anything."""
+    Spyrer's launchers are untouched, the pick goes with the item, and a
+    step back is an ordinary change that owes nobody anything."""
 
     def test_another_spyrers_launchers_are_untouched(
         self, gang, spyrer, orrus, bolt_launchers, bolt_launcher_tiers
@@ -429,7 +471,7 @@ class TestTheLadderIsTheModelsOwn:
 
         assert stat_of(gun_of(orrus, "Bolt launchers"), "L") == "2"
         assert stat_of(gun_of(other, "Bolt launchers"), "L") == "1"
-        assert not ladder_of(other, "Bolt launchers").is_resolved
+        assert not gun_of(other, "Bolt launchers").choices[0].is_resolved
         assert_reconciled(gang)
 
     def test_a_ladder_bought_into_the_stash_follows_the_item_to_its_carrier(
@@ -440,12 +482,12 @@ class TestTheLadderIsTheModelsOwn:
         when a model takes the item up."""
         model = hire(gang, spyrer, "Orrus", paid=200)
         stashed = buy(gang.stash, thing=bolt_launchers, paid=0)
-        _, computed = card_for(model)
-        assert [line.kind_label for line in computed.choices] == []
+        drawn, _ = card_for(model)
+        assert drawn.questions == []
 
         move(stashed, model)
 
-        assert not ladder_of(model, "Bolt launchers").is_resolved
+        assert not gun_of(model, "Bolt launchers").choices[0].is_resolved
         climb(model, "Bolt launchers", bolt_launcher_tiers["Tier 1"])
         assert stat_of(gun_of(model, "Bolt launchers"), "L") == "2"
         assert_reconciled(gang)
@@ -477,7 +519,7 @@ class TestTheLadderIsTheModelsOwn:
                 "Targeting rig augmentation",
                 augmentation,
                 table,
-                label="Targeting rig",
+                label="Augmentation",
                 min_picks=0,
                 max_picks=1,
             ),
@@ -486,13 +528,15 @@ class TestTheLadderIsTheModelsOwn:
         other_launchers = buy(other, thing=bolt_launchers, paid=0)
         launchers = orrus.assignments.get(weapon__isnull=False, archived=False)
         bolted = attach(launchers, sight, paid=0)
-        assert not ladder_of(orrus, "Targeting rig").is_resolved
+        assert choice_behind(orrus, bolted) is not None
 
         move(bolted, other_launchers)
 
         _, computed = card_for(orrus)
-        assert "Targeting rig" not in [line.kind_label for line in computed.choices]
-        climb(other, "Targeting rig", tier)
+        assert not any(
+            line.anchor.caused_by_key == bolted.pk for line in computed.choices
+        )
+        set_level(choice_behind(other, bolted), tier)
         assert stat_of(gun_of(other, "Bolt launchers"), "L") == "3"
         assert stat_of(gun_of(orrus, "Bolt launchers"), "L") == "1"
         assert_reconciled(gang)
@@ -500,21 +544,21 @@ class TestTheLadderIsTheModelsOwn:
     def test_a_climbed_ladder_goes_back_to_the_stash_with_the_item(
         self, gang, orrus, bolt_launcher_tiers
     ):
-        """The other way: stashing the gun takes its rungs out of play
-        and off the model's card, and they return when it is taken up."""
+        """The other way: stashing the gun takes its level out of play and
+        off the model's card, and it returns when the gun is taken up."""
         climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 1"])
         launchers = orrus.assignments.get(weapon__isnull=False, archived=False)
 
         move(launchers, gang.stash)
-        _, computed = card_for(orrus)
-        assert [line.kind_label for line in computed.choices] == []
+        drawn, _ = card_for(orrus)
+        assert drawn.questions == []
 
         move(launchers, orrus)
         assert stat_of(gun_of(orrus, "Bolt launchers"), "L") == "2"
-        assert len(ladder_of(orrus, "Bolt launchers").picks) == 1
+        assert [c.chosen for c in gun_of(orrus, "Bolt launchers").choices] == ["Tier 1"]
         assert_reconciled(gang)
 
-    def test_losing_the_item_takes_the_ladder_and_its_rungs(
+    def test_losing_the_item_takes_the_ladder_and_its_level(
         self, gang, orrus, bolt_launcher_tiers
     ):
         climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 1"])
@@ -522,27 +566,133 @@ class TestTheLadderIsTheModelsOwn:
 
         remove(launchers)
 
-        _, computed = card_for(orrus)
-        assert [line.kind_label for line in computed.choices] == []
+        drawn, _ = card_for(orrus)
+        assert drawn.questions == []
         assert not Assignment.objects.filter(
             pickable=bolt_launcher_tiers["Tier 1"], archived=False
         ).exists()
         assert_reconciled(gang)
 
-    def test_stepping_back_a_rung_is_a_removal_that_refunds_nothing(
+    def test_stepping_back_a_level_is_a_change_that_refunds_nothing(
         self, gang, orrus, bolt_launcher_tiers
     ):
-        climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 1"])
-        second = climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 2"])
+        """A glitch can lower an item's level. The player picks the tier
+        below, which replaces the one held; nothing was paid for either,
+        so nothing comes back."""
+        climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 2"])
         gang.refresh_from_db()
         credits_before = gang.credits
 
-        remove(second)
+        climb(orrus, "Bolt launchers", bolt_launcher_tiers["Tier 1"])
 
         gun = gun_of(orrus, "Bolt launchers")
         assert stat_of(gun, "AP") == "-1"
         assert stat_of(gun, "L") == "2"
-        assert len(ladder_of(orrus, "Bolt launchers").picks) == 1
+        assert [c.chosen for c in gun.choices] == ["Tier 1"]
         gang.refresh_from_db()
         assert gang.credits == credits_before
+        assert_reconciled(gang)
+
+
+class TestALaterTierWinsOverAnEarlierOne:
+    """The mirror shield's tiers: a 6+ field save at Tier 1, a longer range
+    at Tier 2, a 5+ field save at Tier 3. Tier 3 changes what Tier 1
+    changed. Because an item holds one level and each tier carries the
+    whole of being at that level, Tier 3's author writes the 5+ save
+    and the range and nothing about the 6+; when Tier 3 replaces the
+    earlier level there is nothing left to arbitrate."""
+
+    @pytest.fixture
+    def mirror_shield(self, weapon_statline_type, augmentation, fighter_stats):
+        shield = create_weapon(
+            "Mirror shield", profiles=(("", 0),), statline_type=weapon_statline_type
+        )
+        (profile,) = shield.profiles.all()
+        set_statline(
+            profile,
+            short_range=4,
+            long_range=8,
+            strength=3,
+            armour_piercing=0,
+            lethality=1,
+        )
+        long_range = weapon_statline_type.stats.get(stat__short_name="LR").stat
+        save_6 = create_rule("Field armour save", annotation="6+")
+        save_5 = create_rule("Field armour save", annotation="5+")
+
+        def reach():
+            return (
+                targets_weapons(is_one_of(shield)),
+                changes_stat(long_range, mode="set", amount=12),
+            )
+
+        tiers = {
+            "Tier 1": create_pickable(
+                "Tier 1",
+                augmentation,
+                qualifier="Mirror shield",
+                effects=[(targets_model(), adds(save_6))],
+            ),
+            "Tier 2": create_pickable(
+                "Tier 2",
+                augmentation,
+                qualifier="Mirror shield",
+                effects=[(targets_model(), adds(save_6)), reach()],
+            ),
+            "Tier 3": create_pickable(
+                "Tier 3",
+                augmentation,
+                qualifier="Mirror shield",
+                effects=[(targets_model(), adds(save_5)), reach()],
+            ),
+        }
+        table = create_picklist(
+            "Mirror shield augmentations", augmentation, members=list(tiers.values())
+        )
+        add_built_in(
+            shield,
+            create_slot(
+                "Mirror shield augmentation",
+                augmentation,
+                table,
+                label="Augmentation",
+                min_picks=0,
+                max_picks=1,
+            ),
+        )
+        return shield, tiers
+
+    def rules_of(self, miniature):
+        drawn, _ = card_for(miniature)
+        return [line.name for line in drawn.rules]
+
+    def test_tier_three_carries_the_better_save_and_not_the_earlier_one(
+        self, gang, spyrer, mirror_shield
+    ):
+        shield, tiers = mirror_shield
+        jakara = hire(gang, spyrer, "Jakara", paid=200)
+        buy(jakara, thing=shield, paid=0)
+
+        climb(jakara, "Mirror shield", tiers["Tier 1"])
+        assert self.rules_of(jakara) == ["Field armour save (6+)"]
+        assert stat_of(gun_of(jakara, "Mirror shield"), "LR") == '8"'
+
+        climb(jakara, "Mirror shield", tiers["Tier 3"])
+        assert self.rules_of(jakara) == ["Field armour save (5+)"]
+        assert stat_of(gun_of(jakara, "Mirror shield"), "LR") == '12"'
+        assert [c.chosen for c in gun_of(jakara, "Mirror shield").choices] == ["Tier 3"]
+        assert_reconciled(gang)
+
+    def test_stepping_back_to_tier_one_restores_the_earlier_save(
+        self, gang, spyrer, mirror_shield
+    ):
+        shield, tiers = mirror_shield
+        jakara = hire(gang, spyrer, "Jakara", paid=200)
+        buy(jakara, thing=shield, paid=0)
+        climb(jakara, "Mirror shield", tiers["Tier 3"])
+
+        climb(jakara, "Mirror shield", tiers["Tier 1"])
+
+        assert self.rules_of(jakara) == ["Field armour save (6+)"]
+        assert stat_of(gun_of(jakara, "Mirror shield"), "LR") == '8"'
         assert_reconciled(gang)

--- a/n26/tests/sandbox/test_spyrer_augmentations.py
+++ b/n26/tests/sandbox/test_spyrer_augmentations.py
@@ -34,6 +34,7 @@ reason: a scope naming a weapon reaches every copy the model carries.
 
 import pytest
 from django.contrib.auth.models import User
+from django.urls import reverse
 
 from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
@@ -703,3 +704,20 @@ class TestALaterTierWinsOverAnEarlierOne:
         assert self.rules_of(jakara) == ["Field armour save (6+)"]
         assert stat_of(gun_of(jakara, "Mirror shield"), "LR") == '8"'
         assert_reconciled(gang)
+
+
+class TestThePickerNamesTheItem:
+    """Opened from the weapon's sub-row, the pick screen says which item
+    the level is on as well as whose card it is."""
+
+    def test_the_lead_names_the_launchers_and_the_bearer(
+        self, client, owner, gang, orrus, bolt_launcher_tiers
+    ):
+        ladder = ladder_of(orrus, "Bolt launchers")
+        key = f"{orrus.pk}:{ladder.anchor.assignment.pk}:{ladder.identity.pk}"
+        client.force_login(owner)
+
+        page = client.get(reverse("n26-choose", args=[gang.pk, key])).content.decode()
+
+        assert "Bolt launchers, for Orrus." in page
+        assert 'aria-label="Add Tier 1"' in page or "Tier 1" in page

--- a/n26/tests/sandbox/test_spyrer_augmentations.py
+++ b/n26/tests/sandbox/test_spyrer_augmentations.py
@@ -539,6 +539,13 @@ class TestTheLadderIsTheModelsOwn:
         set_level(choice_behind(other, bolted), tier)
         assert stat_of(gun_of(other, "Bolt launchers"), "L") == "3"
         assert stat_of(gun_of(orrus, "Bolt launchers"), "L") == "1"
+        # The part hangs off the gun, so its choice draws under the gun
+        # beside the gun's own — and nowhere else on the card.
+        drawn, _ = card_for(other)
+        gun = next(w for w in drawn.weapons if w.name == "Bolt launchers")
+        assert sorted(c.chosen or "" for c in gun.choices) == ["", "Tier 1"]
+        assert drawn.row_questions == []
+        assert len(gun_of(orrus, "Bolt launchers").choices) == 1
         assert_reconciled(gang)
 
     def test_a_climbed_ladder_goes_back_to_the_stash_with_the_item(

--- a/n26/tests/sandbox/test_spyrer_augmentations.py
+++ b/n26/tests/sandbox/test_spyrer_augmentations.py
@@ -40,7 +40,7 @@ from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled
-from n26.core.render import build_model_card
+from n26.core.render import build_model_card, option_key
 from n26.library.authoring import is_one_of, targets_weapons
 from n26.library.models import Stat, StatlineType, StatlineTypeStat
 from n26.tests.sandbox.actions import (
@@ -721,3 +721,60 @@ class TestThePickerNamesTheItem:
 
         assert "Bolt launchers, for Orrus." in page
         assert 'aria-label="Add Tier 1"' in page or "Tier 1" in page
+
+
+class TestThePickerReturnsWhereItWasOpened:
+    """A link from the model's own page carries that page's address, and
+    settling the choice lands the reader back there. An address that is
+    not this site's own falls back to the gang."""
+
+    def picker(self, gang, orrus):
+        ladder = ladder_of(orrus, "Bolt launchers")
+        key = f"{orrus.pk}:{ladder.anchor.assignment.pk}:{ladder.identity.pk}"
+        return reverse("n26-choose", args=[gang.pk, key])
+
+    def test_the_edit_page_links_its_choice_with_its_own_address(
+        self, client, owner, gang, orrus, bolt_launcher_tiers
+    ):
+        client.force_login(owner)
+        edit = reverse("n26-edit-fighter", args=[orrus.pk])
+
+        page = client.get(edit).content.decode()
+
+        assert f"return={edit}" in page.replace("%2F", "/")
+
+    def test_saving_from_the_edit_page_lands_back_on_it(
+        self, client, owner, gang, orrus, bolt_launcher_tiers
+    ):
+        client.force_login(owner)
+        edit = reverse("n26-edit-fighter", args=[orrus.pk])
+        picker = self.picker(gang, orrus)
+
+        page = client.get(f"{picker}?return={edit}").content.decode()
+        assert f'name="return" value="{edit}"' in page
+
+        reply = client.post(
+            picker,
+            {"thing": option_key(bolt_launcher_tiers["Tier 2"]), "return": edit},
+        )
+
+        assert reply.status_code == 302
+        assert reply.url == edit
+        assert [c.chosen for c in gun_of(orrus, "Bolt launchers").choices] == ["Tier 2"]
+
+    def test_an_address_that_is_not_ours_falls_back_to_the_gang(
+        self, client, owner, gang, orrus, bolt_launcher_tiers
+    ):
+        client.force_login(owner)
+        picker = self.picker(gang, orrus)
+
+        reply = client.post(
+            picker,
+            {
+                "thing": option_key(bolt_launcher_tiers["Tier 1"]),
+                "return": "https://elsewhere.example/steal",
+            },
+        )
+
+        assert reply.status_code == 302
+        assert reply.url == reverse("n26-gang", args=[gang.pk])


### PR DESCRIPTION
## Summary

- **An item's augmentation level draws under the item, as n23 prints it.** A slot built into a weapon is materialised beside the model and caused by the weapon's assignment, so the card builder can tell which weapon a choice belongs to (`weapon_home` in `n26/core/render.py`, beside `question_row`). Such a choice files onto `WeaponLine.choices` and stays out of the card's own rows. The gang-sheet card draws a sub-row under the weapon reading "Augmentation: Tier 1"; the model's own page, which draws the card in edit mode, adds a Change or Choose link to the picker; the print sheet and text card carry the level in the weapon's line. `ModelCard.questions` now includes weapon-hosted choices so the picker links and the row guard still reach them; `row_questions` is what paper draws as rows.
- **An item has one level.** The rules give each item one augmentation level that rises or falls by one, and n23's content restates the lower rungs' effects on each higher rung. The Spyrer suite now builds the ladder as a one-pick slot whose tiers each carry the whole effect of being at that level, picking Tier 2 replaces Tier 1, and a step back is picking the tier below. The stacking-picks reading from #2514 is withdrawn. Tiers still carry no rating; the credit figure sits on the Power Boost result. A later tier that changes what an earlier one changed (a 6+ field save at Tier 1, 5+ at Tier 3) simply carries the later value: with one pick there is nothing to arbitrate.
- **The picker names the item.** Opened from a weapon's choice, the pick screen's lead reads "Paired bolt launchers, for Vaelen Orrus." rather than only the model.
- The cookbook gains "An item's augmentation tiers" with the authoring steps; the gallery's sample card carries a lasgun at Tier 2 so the sub-row is documented in both modes.

Fourth PR of the Spyrer suit evolution plan (`.claude/notes/issue-2313-plan.md`), after #2500, #2514 and #2520. No migration. Weapons only: a wargear's ladder still draws as its own line under Gear until the gear line carries it.

Screens, from a local Spyre Hunters gang:

- Gang sheet: `Paired bolt launchers … Rapid Fire (2)` then `Augmentation: Tier 1` under it, no Gear choice line.
- Model edit page: the same sub-row with `Change`.
- Picker: "Augmentation — Paired bolt launchers, for Vaelen Orrus." with Tier 1 / Tier 2 / Tier 3 / None.
- Print: `Paired bolt launchers / Augmentation: Tier 1` in the weapon cell.

## Test plan

- [x] `pytest -n 4 n26` — 6149 passed, 1 xfailed
- [x] `test_spyrer_augmentations.py` rewritten for one level per item (16 tests): the choice is on `weapon.choices` and `card.questions`, never `card.choices`; Tier 2 replaces Tier 1 and keeps its change; step back; stash both ways; a bolted-on part's ladder follows it between guns; the mirror shield's Tier 3 (5+ save) replaces Tier 1's 6+ rather than sitting beside it
- [x] `test_card_rows.py`: a weapon's question is in `questions`, not in `row_questions`, gets its href from `link_slots`, and the template draws `weapon.choices`
- [x] Print, text-card, render-budget and gallery suites green
- [ ] Manual: on a Spyrer's card the level sits under the weapon; Change on the model's page opens the picker

Refs #2313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iDzmtRyyVqZjjMi3U5o1A
