### PR TITLE
fix: n26 deletion stack review fixes — emptied columns, campaign locks, per-gang re-check, idempotent redelivery

### DIFF
--- a/n26/library/deletion.py
+++ b/n26/library/deletion.py
@@ -432,16 +432,20 @@ class _Planner:
         if _key(row) in self.doomed:
             return
         label = reference.label
-        if label.startswith("n26."):
-            self.sort_player_row(reference)
-            return
-        if reference.cascades:
+        if reference.cascades and label.startswith("library."):
             # A part of the thing: it goes, and what it holds is read.
             self.doom(row)
             return
-        if not reference.protects and not reference.empties:
+        if not reference.protects:
             # A list membership — a trait on a firing line, a modifier
-            # on a carrier — is forgotten, not deleted.
+            # on a carrier — is forgotten, not deleted. A column that is
+            # emptied — a purchase's list line, a pick's offer — was
+            # declared that way because the row it names may go while
+            # the row naming it stays true. A player-side row that
+            # cascades goes with the thing.
+            return
+        if label.startswith("n26."):
+            self.sort_player_row(reference)
             return
         self.sort_library_row(reference, thing_model)
 
@@ -572,12 +576,6 @@ class _Planner:
             gang = self.gang_of_assignment(row.assignment)
         elif label == "n26.statoverride":
             gang = row.miniature.gang
-        elif label == "n26.ledgerentry":
-            gang = self.gang_of_assignment(row.assignment)
-        elif label == "n26.ledgerevent":
-            gang = row.gang
-        elif reference.cascades:
-            return
         if gang is not None:
             self.hold("gang", gang, f"{what} ({_kind(self.doomed_row(reference))})")
             return
@@ -860,7 +858,9 @@ def remove_free_lines_from(gang_id, plan):
         gang = Gang.objects.select_for_update().get(pk=gang_id)
         now = plan_again(plan)
         if now.refusals:
-            return f"gang {gang.name}: skipped — " + "; ".join(now.refusals)
+            # Raised rather than returned: a gang left alone is a run
+            # that did not finish, and the record must not end as done.
+            raise Refused(f"gang {gang.name}: " + "; ".join(now.refusals))
         mine = [line for line in now.lines if str(line.pk) == str(gang.pk)]
         if not mine:
             return f"gang {gang.name}: nothing left to remove"
@@ -868,9 +868,9 @@ def remove_free_lines_from(gang_id, plan):
         list(Assignment.objects.select_for_update().filter(pk__in=ids).order_by("pk"))
         problems = check_gang(gang)
         if problems:
-            return (
-                f"gang {gang.name}: skipped — it did not reconcile before the "
-                "removal: " + "; ".join(problems)
+            raise Refused(
+                f"gang {gang.name} did not reconcile before the removal: "
+                + "; ".join(problems)
             )
         Assignment.objects.filter(pk__in=ids).delete()
         problems = check_gang(gang)
@@ -927,6 +927,14 @@ def apply(plan, actor=None):
         list(
             Gang.objects.select_for_update()
             .filter(pk__in=[gang.pk for gang in plan.test_gangs])
+            .order_by("pk")
+        )
+        # The campaigns as well: joining one takes a key-share lock on
+        # its row, which this conflicts with, so no player can join
+        # between the second reading and the delete.
+        list(
+            Campaign.objects.select_for_update()
+            .filter(pk__in=[campaign.pk for campaign in plan.test_campaigns])
             .order_by("pk")
         )
         for label, pk in plan.targets:

--- a/n26/library/deletion.py
+++ b/n26/library/deletion.py
@@ -348,6 +348,7 @@ class _Planner:
         self.lines = {}
         self.refusals = []
         self.queue = []
+        self._gangs = {}
 
     # -- what goes -------------------------------------------------------
 
@@ -594,11 +595,17 @@ class _Planner:
         return reference.row._meta.get_field(reference.field).related_model
 
     def gang_of_assignment(self, assignment):
+        """The gang an assignment is rooted on, read once per gang: a
+        line a hundred fighters have is a hundred references to the
+        same few gangs."""
         from n26.core.models import Gang
 
-        if assignment.gang_root_id:
-            return Gang.objects.select_related("owner").get(pk=assignment.gang_root_id)
-        return None
+        gang_id = assignment.gang_root_id
+        if not gang_id:
+            return None
+        if gang_id not in self._gangs:
+            self._gangs[gang_id] = Gang.objects.select_related("owner").get(pk=gang_id)
+        return self._gangs[gang_id]
 
     def campaign_goes(self, campaign):
         """A campaign that goes takes its own type, its pack and every
@@ -841,12 +848,15 @@ def remove_free_lines_from(gang_id, plan):
     """Take the plan's firing line off one gang's fighters, committed on
     its own, and delete the row once no fighter anywhere has it.
 
-    The line is read again under the gang's lock — deliveries may be
-    minutes apart — and a fighter who has since paid for it, or whose
-    line has something under it, leaves the gang alone and named. The
-    assignments go with their zero-value entries and events, and the
-    gang is proved to reconcile before and after. The last gang visited
-    finds nothing else naming the row and deletes it.
+    Only this gang's lines are read again, under its lock — deliveries
+    may be minutes apart — and a line since paid for, or with something
+    under it, fails the gang in words, so the run ends as not done
+    rather than as done with the row still standing. The estate as a
+    whole was read once, when the run began. The assignments go with
+    their zero-value entries and events, and the gang is proved to
+    reconcile before and after. The last gang visited finds nothing
+    else naming the row and deletes it. A row already gone means a
+    delivery replayed after the work: nothing left to do.
     """
     from django.apps import apps
 
@@ -854,38 +864,56 @@ def remove_free_lines_from(gang_id, plan):
     from n26.core.reconcile import check_gang
     from n26.library import authoring
 
+    targets = [
+        apps.get_model(label).objects.filter(pk=pk).first()
+        for label, pk in plan.targets
+    ]
+    if all(row is None for row in targets):
+        return "nothing left to remove: the line is already gone"
     with transaction.atomic():
         gang = Gang.objects.select_for_update().get(pk=gang_id)
-        now = plan_again(plan)
-        if now.refusals:
-            # Raised rather than returned: a gang left alone is a run
-            # that did not finish, and the record must not end as done.
-            raise Refused(f"gang {gang.name}: " + "; ".join(now.refusals))
-        mine = [line for line in now.lines if str(line.pk) == str(gang.pk)]
+        mine = [line for line in plan.lines if str(line.pk) == str(gang.pk)]
         if not mine:
             return f"gang {gang.name}: nothing left to remove"
-        ids = [pk for pk in mine[0].assignment_ids]
-        list(Assignment.objects.select_for_update().filter(pk__in=ids).order_by("pk"))
+        held = list(
+            Assignment.objects.select_for_update()
+            .filter(pk__in=list(mine[0].assignment_ids))
+            .order_by("pk")
+        )
+        for line in held:
+            why_not = _why_not_a_free_line(line)
+            if why_not:
+                fighter = (
+                    line.miniature_root.name if line.miniature_root_id else "a fighter"
+                )
+                # Raised rather than returned: a gang left alone is a run
+                # that did not finish, and the record must not end as done.
+                raise Refused(
+                    f"gang {gang.name}: the line on {fighter} {why_not}; refund "
+                    "or remove it first"
+                )
+        if not held:
+            return f"gang {gang.name}: nothing left to remove"
         problems = check_gang(gang)
         if problems:
             raise Refused(
                 f"gang {gang.name} did not reconcile before the removal: "
                 + "; ".join(problems)
             )
-        Assignment.objects.filter(pk__in=ids).delete()
+        Assignment.objects.filter(pk__in=[line.pk for line in held]).delete()
         problems = check_gang(gang)
         if problems:
             raise Refused(
                 f"gang {gang.name} did not reconcile after removing the line: "
                 + "; ".join(problems)
             )
-        fighters = len(ids)
+        fighters = len(held)
         said = f"gang {gang.name}: removed the line from {fighters} fighter{'' if fighters == 1 else 's'}"
         # The row goes with the last fighter: after this gang, nothing
-        # may name it any more.
-        for label, pk in plan.targets:
-            row = apps.get_model(label).objects.filter(pk=pk).first()
-            if row is None:
+        # may name it any more. Asked cheaply first; the full reading
+        # only once the last line is gone.
+        for row in targets:
+            if row is None or Assignment.objects.filter(weapon_profile=row).exists():
                 continue
             if not plan_deletion([row]).ok:
                 continue

--- a/n26/library/merging.py
+++ b/n26/library/merging.py
@@ -428,11 +428,19 @@ def merge_gang(gang_id, plan):
     was read is repointed like the rest — it names the same thing —
     and a line that has no counterpart refuses, naming it. The books
     are checked before and after; the entries are untouched, so the
-    numbers cannot move, and the check is what proves it.
+    numbers cannot move, and the check is what proves it. A duplicate
+    already gone means a delivery replayed after the work: nothing left
+    to do.
     """
+    from django.apps import apps
+
     from n26.core.models import Assignment, Gang, LedgerEntry, Reason
     from n26.core.reconcile import check_gang
 
+    label, pk = plan.duplicate
+    if not apps.get_model(label).objects.filter(pk=pk).exists():
+        # A delivery replayed after the last gang finished the merge.
+        return "nothing left to move: the duplicate is already gone"
     with transaction.atomic():
         gang = Gang.objects.select_for_update().get(pk=gang_id)
         duplicate, survivor = _rows(plan)
@@ -493,6 +501,10 @@ def merge_gang(gang_id, plan):
         # have with the survivor bought outright. Written directly: the
         # gang's history must not say its owner did something today.
         granted = 0
+        # Every free line of the survivor, as an outright purchase grants
+        # them. A list that prices one of those lines on its own is not
+        # known here — the purchase's list is not read — so such a line
+        # arrives free where the list would have charged for it.
         free = [line for line in _lines_of(survivor) if line.price == 0]
         for weapon in Assignment.objects.filter(pk__in=[a.pk for a in held]):
             has = set(
@@ -577,6 +589,7 @@ def merge_library(plan):
             )
         to_line = {dup: survivor_pk for dup, _, survivor_pk in mapping}
         things = [duplicate, *_lines_of(duplicate)]
+        survivor_lines = {str(line.pk): line for line in _lines_of(survivor)}
         by_model = {}
         for thing in things:
             by_model.setdefault(type(thing), []).append(thing)
@@ -585,11 +598,11 @@ def merge_library(plan):
             for reference in references_to(*rows):
                 row = reference.row
                 label = reference.label
-                target = (
-                    _line_target(row, reference.field, to_line)
-                    if reference.field == "weapon_profile"
-                    else survivor
-                )
+                if reference.field == "weapon_profile":
+                    current = str(getattr(row, "weapon_profile_id", ""))
+                    target = survivor_lines.get(to_line.get(current, ""))
+                else:
+                    target = survivor
                 if label == "n26.assignment":
                     raise Refused(
                         f"a fighter still has {_said(duplicate)}; run the merge again"
@@ -611,10 +624,17 @@ def merge_library(plan):
                 if reference.cascades:
                     continue
                 if not reference.protects and not reference.empties:
-                    # A many-to-many listing the duplicate: swapped.
+                    # A many-to-many listing the duplicate: swapped, each
+                    # member for its own counterpart.
                     manager = getattr(row, reference.field)
-                    manager.remove(*[t for t in things if isinstance(t, model)])
-                    manager.add(target)
+                    listed = [t for t in things if isinstance(t, model)]
+                    manager.remove(*listed)
+                    for member in listed:
+                        manager.add(
+                            survivor_lines[to_line[str(member.pk)]]
+                            if str(member.pk) in to_line
+                            else survivor
+                        )
                     moved += 1
                     continue
                 if (
@@ -636,10 +656,3 @@ def merge_library(plan):
         if dropped:
             said += f", dropped {dropped} list line{'' if dropped == 1 else 's'} already offered"
         return said + f"; deleted {plan.duplicate_said}"
-
-
-def _line_target(row, field, to_line):
-    from n26.library.models import WeaponProfile
-
-    current = getattr(row, f"{field}_id")
-    return WeaponProfile.objects.get(pk=to_line[str(current)])

--- a/n26/library/merging.py
+++ b/n26/library/merging.py
@@ -458,9 +458,9 @@ def merge_gang(gang_id, plan):
             return f"gang {gang.name}: nothing left to move"
         problems = check_gang(gang)
         if problems:
-            return (
-                f"gang {gang.name}: skipped — it did not reconcile before the "
-                "merge: " + "; ".join(problems)
+            raise Refused(
+                f"gang {gang.name} did not reconcile before the merge: "
+                + "; ".join(problems)
             )
 
         moved = 0

--- a/n26/library/staged.md
+++ b/n26/library/staged.md
@@ -115,7 +115,7 @@ thing — a live fighter's kit brought it, or you let them in with the
 staged-content flag — the delete page names the gang and its owner, and
 nothing is deleted. The same goes for a campaign a player is in.
 
-A gang type refuses to be deleted while fighters are written for it.
+A gang type cannot be deleted while fighters are written for it.
 Delete the fighters first, or delete everything staged together, which
 plans the whole set at once so that nothing refuses because of another
 staged thing.

--- a/n26/library/templates/authoring/_deletion_plan.html
+++ b/n26/library/templates/authoring/_deletion_plan.html
@@ -44,9 +44,11 @@ _deletion_words in n26/library/views.py. Nothing here changes anything.
                         <td class="whitespace-nowrap">
                             {{ line.name }}
                             {% if line.archived %}
-                                <c-ui.badge color="gray" size="sm" class="ml-1">
-                                    Archived
-                                </c-ui.badge>
+                                <span class="ml-1">
+                                    <c-ui.badge color="zinc" size="sm">
+                                        Archived
+                                    </c-ui.badge>
+                                </span>
                             {% endif %}
                         </td>
                         <td class="whitespace-nowrap">{{ line.owner }}</td>
@@ -74,9 +76,11 @@ _deletion_words in n26/library/views.py. Nothing here changes anything.
                         <td class="whitespace-nowrap">
                             {{ campaign.name }}
                             {% if campaign.archived %}
-                                <c-ui.badge color="gray" size="sm" class="ml-1">
-                                    Archived
-                                </c-ui.badge>
+                                <span class="ml-1">
+                                    <c-ui.badge color="zinc" size="sm">
+                                        Archived
+                                    </c-ui.badge>
+                                </span>
                             {% endif %}
                         </td>
                         <td class="whitespace-nowrap">{{ campaign.owner }}</td>
@@ -104,9 +108,11 @@ _deletion_words in n26/library/views.py. Nothing here changes anything.
                         <td class="whitespace-nowrap">
                             {{ gang.name }}
                             {% if gang.archived %}
-                                <c-ui.badge color="gray" size="sm" class="ml-1">
-                                    Archived
-                                </c-ui.badge>
+                                <span class="ml-1">
+                                    <c-ui.badge color="zinc" size="sm">
+                                        Archived
+                                    </c-ui.badge>
+                                </span>
                             {% endif %}
                         </td>
                         <td class="whitespace-nowrap">{{ gang.owner }}</td>

--- a/n26/library/templates/authoring/_deletion_plan.html
+++ b/n26/library/templates/authoring/_deletion_plan.html
@@ -1,9 +1,9 @@
 {% comment %}
 What a delete would take, drawn on every page that asks the question:
 what goes, the fighters a firing line is removed from, the test gangs
-that go with it, and what refuses it. Takes `counts`, `lines`,
-`test_gangs` and `refusals` from _deletion_words in
-n26/library/views.py. Nothing here changes anything.
+and test campaigns that go with it, and what refuses it. Takes
+`counts`, `lines`, `test_gangs`, `test_campaigns` and `refusals` from
+_deletion_words in n26/library/views.py. Nothing here changes anything.
 {% endcomment %}
 {% if refusals %}
     <c-ui.alert variant="error" title="Something still holds it">
@@ -51,6 +51,36 @@ n26/library/views.py. Nothing here changes anything.
                         </td>
                         <td class="whitespace-nowrap">{{ line.owner }}</td>
                         <td class="text-muted">{{ line.fighters }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </c-ui.table>
+    </c-n26.form-section>
+{% endif %}
+{% if test_campaigns and not refusals %}
+    <c-n26.form-section title="Test campaigns that go with it"
+                        description="Each is run by staff and every gang in it is a test gang. It is deleted whole: its log, its battles, its assets, and the campaign type and pack of its own.">
+        <c-ui.table>
+            <thead>
+                <tr>
+                    <th scope="col">Campaign</th>
+                    <th scope="col">Arbitrator</th>
+                    <th scope="col" class="w-full">Holds</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for campaign in test_campaigns %}
+                    <tr>
+                        <td class="whitespace-nowrap">
+                            {{ campaign.name }}
+                            {% if campaign.archived %}
+                                <c-ui.badge color="gray" size="sm" class="ml-1">
+                                    Archived
+                                </c-ui.badge>
+                            {% endif %}
+                        </td>
+                        <td class="whitespace-nowrap">{{ campaign.owner }}</td>
+                        <td class="text-muted">{{ campaign.holds }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/n26/library/templates/authoring/deletion.html
+++ b/n26/library/templates/authoring/deletion.html
@@ -26,7 +26,7 @@ script is needed, and a reader who leaves and comes back sees the same.
         </c-slot>
     </c-n26.page-header>
     {% if error %}
-        <c-ui.alert variant="error" title="Why" class="mt-6">
+        <c-ui.alert variant="error" title="What stopped it" class="mt-6">
             {{ error }}
         </c-ui.alert>
     {% endif %}

--- a/n26/library/templates/authoring/thing_delete.html
+++ b/n26/library/templates/authoring/thing_delete.html
@@ -14,7 +14,7 @@ the author's own test gang, and the page lists those before the click.
 {% block content %}
     <c-n26.form-page action="{% url 'authoring-thing-delete' kind thing.pk %}"
                      title="Delete {{ label }}?"
-                     lead="For good: the {{ verbose_name }} leaves the library{% if test_gangs %}, and so do the test gangs holding it{% endif %}. You cannot undo this."
+                     lead="For good: the {{ verbose_name }} leaves the library{% if test_gangs or test_campaigns %}, and so do the test gangs holding it{% endif %}. You cannot undo this."
                      submit_label="{{ submit_label }}"
                      submit_variant="danger"
                      cancel_url="{{ back }}">
@@ -31,7 +31,7 @@ the author's own test gang, and the page lists those before the click.
         </c-slot>
         {% csrf_token %}
         {% include "authoring/_deletion_plan.html" %}
-        {% if not refusals and not test_gangs %}
+        {% if not refusals and not test_gangs and not test_campaigns %}
             <c-ui.alert variant="info" title="Nothing else holds it">
                 No gang has it, no list offers it and no option brings it,
                 so only the {{ verbose_name }} itself goes.

--- a/n26/library/templates/authoring/thing_merge.html
+++ b/n26/library/templates/authoring/thing_merge.html
@@ -84,9 +84,11 @@ would then post the act. Nothing here changes anything until the act.
                                             <td class="whitespace-nowrap">
                                                 {{ gang.name }}
                                                 {% if gang.archived %}
-                                                    <c-ui.badge color="gray" size="sm" class="ml-1">
-                                                        Archived
-                                                    </c-ui.badge>
+                                                    <span class="ml-1">
+                                                        <c-ui.badge color="zinc" size="sm">
+                                                            Archived
+                                                        </c-ui.badge>
+                                                    </span>
                                                 {% endif %}
                                             </td>
                                             <td class="whitespace-nowrap">{{ gang.owner }}</td>

--- a/n26/library/templates/authoring/weapon_profile_delete.html
+++ b/n26/library/templates/authoring/weapon_profile_delete.html
@@ -52,8 +52,7 @@ removed from them before it goes.
         {% endcomment %}
         <c-ui.alert variant="info" title="{{ weapon }} is not deleted">
             The weapon stays in the library with its other lines. A weapon
-            with no lines at all is a fine thing to have part-way through
-            correcting a table.
+            with no lines is allowed while you correct its table.
         </c-ui.alert>
     </c-n26.form-page>
 {% endblock content %}

--- a/n26/library/templates/authoring/weapon_profile_delete.html
+++ b/n26/library/templates/authoring/weapon_profile_delete.html
@@ -16,7 +16,7 @@ removed from them before it goes.
 {% block content %}
     <c-n26.form-page action="{% url 'authoring-weapon-profile-delete' thing.pk %}"
                      title="Delete {{ label }}?"
-                     lead="For good: the {{ verbose_name }} leaves {{ weapon }}, and its characteristics with it{% if lines %}. The fighters that have it lose the line{% endif %}. You cannot undo this."
+                     lead="For good: the {{ verbose_name }} leaves {{ weapon }}, and its characteristics with it{% if lines and not refusals %}. The fighters that have it lose the line{% endif %}. You cannot undo this."
                      submit_label="{{ submit_label }}"
                      submit_variant="danger"
                      cancel_url="{{ back }}">

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -2970,7 +2970,9 @@ def weapon_profile_delete(request, pk):
     plan = plan_deletion([profile], remove_free_lines=True)
 
     if request.method == "POST":
-        elsewhere = _perform_deletion(request, plan, label)
+        elsewhere = _perform_deletion(
+            request, plan, label, reverse("authoring-weapon-profile-delete", args=[pk])
+        )
         return elsewhere or redirect(back)
 
     return render(
@@ -3317,16 +3319,18 @@ def _deletion_words(plan, label):
     is a question with one answer. A plan taking gangs names them on the
     button, so the count is read before the click, not after.
     """
-    gangs = [
-        {
+
+    def drawn(holder):
+        return {
             "name": holder.name,
             "owner": holder.owner,
             "archived": holder.archived,
             "holds": ", ".join(holder.holds),
         }
-        for holder in (*plan.test_gangs, *plan.test_campaigns)
-    ]
-    campaigns = sum(1 for holder in plan.test_campaigns)
+
+    gangs = [drawn(holder) for holder in plan.test_gangs]
+    test_campaigns = [drawn(holder) for holder in plan.test_campaigns]
+    campaigns = len(test_campaigns)
     lines = [
         {
             "name": line.name,
@@ -3344,7 +3348,7 @@ def _deletion_words(plan, label):
             f"Delete the firing line and remove it from {n} "
             f"fighter{'' if n == 1 else 's'}"
         )
-    elif gangs:
+    elif gangs or campaigns:
         n = len(plan.test_gangs)
         parts = [f"{n} test gang{'' if n == 1 else 's'}"] if n else []
         if campaigns:
@@ -3355,6 +3359,7 @@ def _deletion_words(plan, label):
     return {
         "plan": plan,
         "test_gangs": gangs,
+        "test_campaigns": test_campaigns,
         "lines": lines,
         "fighters_with_lines": plan.fighters_with_lines,
         "refusals": list(plan.refusals),
@@ -3363,7 +3368,7 @@ def _deletion_words(plan, label):
     }
 
 
-def _perform_deletion(request, plan, label):
+def _perform_deletion(request, plan, label, here):
     """Do what a delete page's plan says, and say where to go next.
 
     Three endings. A refusal is said on the page and nothing is
@@ -3371,8 +3376,10 @@ def _perform_deletion(request, plan, label):
     on the task runner, and the reader is sent to the record. A plan
     that takes only library rows is done here, now.
 
-    Returns a redirect for the first two, or ``None`` when the rows were
-    deleted here and the caller decides where to lead.
+    ``here`` is the delete page's own address, reversed by the caller,
+    which is where a refusal leads back to. Returns a redirect for the
+    first two endings, or ``None`` when the rows were deleted here and
+    the caller decides where to lead.
     """
     from n26.library.deletion import Refused, apply
     from n26.maintenance import AnotherRunning, start_authoring_deletion
@@ -3384,7 +3391,7 @@ def _perform_deletion(request, plan, label):
             + "; ".join(plan.refusals)
             + ".",
         )
-        return redirect(request.path)
+        return redirect(here)
     if plan.touches_players:
         try:
             record = start_authoring_deletion(plan, request.user)
@@ -3393,13 +3400,13 @@ def _perform_deletion(request, plan, label):
                 request,
                 "Another deletion is still running. Try again when it has finished.",
             )
-            return redirect(request.path)
+            return redirect(here)
         return redirect("authoring-deletion", pk=record.pk)
     try:
         apply(plan)
     except Refused as refused:
         messages.error(request, f"{label} was not deleted: {refused}.")
-        return redirect(request.path)
+        return redirect(here)
     messages.success(request, f"Deleted {label}.")
     return None
 
@@ -3428,7 +3435,12 @@ def thing_delete(request, kind, pk):
     parent = _parent_of(kind, thing) if kind in NESTED_KINDS else None
 
     if request.method == "POST":
-        elsewhere = _perform_deletion(request, plan_deletion([thing]), label)
+        elsewhere = _perform_deletion(
+            request,
+            plan_deletion([thing]),
+            label,
+            reverse("authoring-thing-delete", args=[kind, pk]),
+        )
         if elsewhere is not None:
             return elsewhere
         if parent is not None:
@@ -3477,21 +3489,25 @@ def thing_merge(request, kind, pk):
     model = _model_for(spec)
     thing = get_object_or_404(model, pk=pk)
     back = reverse("authoring-detail", args=[kind, pk])
+    here = reverse("authoring-thing-merge", args=[kind, pk])
     label = _label_for(thing)
     into = request.POST.get("into") or request.GET.get("into") or ""
     survivor = model.objects.filter(pk=into).first() if into else None
     plan = plan_merge(thing, survivor) if survivor is not None else None
+    # The way back to a chosen plan: the survivor is a row this view
+    # found, so the address names its stored id, never what was typed.
+    chosen = f"{here}?into={survivor.pk}" if survivor is not None else here
 
     if request.method == "POST":
         if plan is None:
             messages.error(request, "Choose what to merge it into.")
-            return redirect(request.path)
+            return redirect(here)
         if plan.refusals:
             messages.error(
                 request,
                 f"{label} was not merged: " + "; ".join(plan.refusals) + ".",
             )
-            return redirect(f"{request.path}?into={survivor.pk}")
+            return redirect(chosen)
         if plan.touches_players:
             try:
                 record = start_authoring_deletion(plan, request.user)
@@ -3500,7 +3516,7 @@ def thing_merge(request, kind, pk):
                     request,
                     "Another merge is still running. Try again when it has finished.",
                 )
-                return redirect(f"{request.path}?into={survivor.pk}")
+                return redirect(chosen)
             return redirect("authoring-deletion", pk=record.pk)
         from n26.library.merging import Refused, merge_library
 
@@ -3508,7 +3524,7 @@ def thing_merge(request, kind, pk):
             merge_library(plan)
         except Refused as refused:
             messages.error(request, f"{label} was not merged: {refused}.")
-            return redirect(f"{request.path}?into={survivor.pk}")
+            return redirect(chosen)
         messages.success(request, f"Merged {label} into {plan.survivor_said}.")
         return redirect("authoring-detail", kind=kind, pk=survivor.pk)
 
@@ -3564,7 +3580,9 @@ def staged_delete(request):
     label = "everything staged"
 
     if request.method == "POST":
-        elsewhere = _perform_deletion(request, plan, label)
+        elsewhere = _perform_deletion(
+            request, plan, label, reverse("authoring-staged-delete")
+        )
         return elsewhere or redirect("authoring-staged")
 
     return render(

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -3340,7 +3340,7 @@ def _deletion_words(plan, label):
         }
         for line in plan.lines
     ]
-    if plan.refusals:
+    if plan.refusals or plan.nothing_here:
         submit_label = ""
     elif lines:
         n = plan.fighters_with_lines
@@ -3492,7 +3492,12 @@ def thing_merge(request, kind, pk):
     here = reverse("authoring-thing-merge", args=[kind, pk])
     label = _label_for(thing)
     into = request.POST.get("into") or request.GET.get("into") or ""
-    survivor = model.objects.filter(pk=into).first() if into else None
+    try:
+        survivor = model.objects.filter(pk=into).first() if into else None
+    except ValidationError, ValueError, TypeError:
+        # Anything that is not an id at all: the field refuses it while
+        # the query is being built, before any row is read.
+        survivor = None
     plan = plan_merge(thing, survivor) if survivor is not None else None
     # The way back to a chosen plan: the survivor is a row this view
     # found, so the address names its stored id, never what was typed.
@@ -3580,6 +3585,9 @@ def staged_delete(request):
     label = "everything staged"
 
     if request.method == "POST":
+        if plan.nothing_here:
+            messages.info(request, "Nothing is staged, so nothing was deleted.")
+            return redirect("authoring-staged")
         elsewhere = _perform_deletion(
             request, plan, label, reverse("authoring-staged-delete")
         )
@@ -3600,13 +3608,13 @@ def deletion(request, pk):
     that asked for it cannot say how it ended. This one can, and it
     reloads itself until there is an ending to say.
     """
-    from n26.maintenance import authoring_deletion
+    from n26.maintenance import Operation, authoring_deletion
 
     record = authoring_deletion(pk)
     if record is None:
         raise Http404("No such deletion")
     summary = record.summary or {}
-    merging = record.operation == "n26_merge_into"
+    merging = record.operation == Operation.MERGE_INTO.value
     return render(
         request,
         "authoring/deletion.html",

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -2061,21 +2061,6 @@ register_operation(
 )
 
 
-#: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
-#: The deadline is the longest Pub/Sub allows, because a repair holds one
-#: transaction for as long as proving what it touched takes. It is also
-#: the request timeout the service is deployed with, and the two belong
-#: together: a run outliving its deadline is delivered again while the first
-#: copy is still working, and the second — standing down at the lock — answers
-#: successfully and acknowledges the message out from under it. Change one and
-#: change the other (``--timeout`` in ``cloudbuild.yaml``).
-#:
-#: The propagation tasks live with the rest of that machinery in
-#: ``n26.core.propagation``; their routes are declared here because this
-#: module is the edition's one door onto the task framework. The sweep
-#: is scheduled work: the framework provisions a Cloud Scheduler job
-#: from the declaration, and only there — the local backend fires no
-#: schedules, so dev and tests invoke the sweep function directly.
 @task
 def delete_test_content(backfill_id, **said_by_whoever_enqueued_it):
     """Delete content and the test gangs holding it, exactly as the
@@ -2243,6 +2228,21 @@ register_operation(
 )
 
 
+#: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
+#: The deadline is the longest Pub/Sub allows, because a repair holds one
+#: transaction for as long as proving what it touched takes. It is also
+#: the request timeout the service is deployed with, and the two belong
+#: together: a run outliving its deadline is delivered again while the first
+#: copy is still working, and the second — standing down at the lock — answers
+#: successfully and acknowledges the message out from under it. Change one and
+#: change the other (``--timeout`` in ``cloudbuild.yaml``).
+#:
+#: The propagation tasks live with the rest of that machinery in
+#: ``n26.core.propagation``; their routes are declared here because this
+#: module is the edition's one door onto the task framework. The sweep
+#: is scheduled work: the framework provisions a Cloud Scheduler job
+#: from the declaration, and only there — the local backend fires no
+#: schedules, so dev and tests invoke the sweep function directly.
 task_routes = [
     TaskRoute(delete_test_content, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_firing_line, ack_deadline=600, min_retry_delay=60),

--- a/n26/tests/sandbox/test_deletion_pages.py
+++ b/n26/tests/sandbox/test_deletion_pages.py
@@ -226,6 +226,11 @@ class TestTheStagedContentPage:
         create_weapon("Lasgun")
         body = client.get(STAGED_DELETE_URL).content.decode()
         assert "Nothing is staged" in body
+        assert "Delete it" not in body
+
+        response = client.post(STAGED_DELETE_URL, follow=True)
+        assert "nothing was deleted" in response.content.decode()
+        assert not Backfill.objects.exists()
 
     def test_it_is_for_staff(self, client, db):
         client.force_login(User.objects.create_user("player"))

--- a/n26/tests/sandbox/test_deletion_pages.py
+++ b/n26/tests/sandbox/test_deletion_pages.py
@@ -82,6 +82,25 @@ class TestARowsDeletePage:
         assert "Delete Test lasgun and 1 test gang" in body
         assert Weapon.objects.filter(pk=test_weapon.pk).exists()
 
+    def test_a_test_campaign_is_named_apart_from_the_gangs(
+        self, author, client, default_pack, test_type, test_fighter, test_weapon
+    ):
+        from n26.library.authoring import create_campaign_type
+        from n26.tests.sandbox.actions import found_campaign, join_campaign
+
+        staged_type = create_campaign_type("Test campaign type", staged=True)
+        mine = checked_by(author, test_type, test_fighter, test_weapon, "Mine")
+        found_campaign("Rehearsal", staged_type, owner=author)
+        campaign = found_campaign("Rehearsal", staged_type, owner=author)
+        join_campaign(mine, campaign)
+
+        body = client.get(delete_page(staged_type, "campaign-type")).content.decode()
+
+        assert "Test campaigns that go with it" in body
+        assert "Rehearsal" in body
+        assert "Test gangs that go with it" in body
+        assert "Delete Test campaign type and 1 test gang and 2 test campaigns" in body
+
     def test_a_players_gang_refuses_before_the_click(
         self, author, client, player, test_type, test_fighter, test_weapon
     ):

--- a/n26/tests/sandbox/test_firing_line_removal.py
+++ b/n26/tests/sandbox/test_firing_line_removal.py
@@ -16,7 +16,7 @@ from django.contrib.auth.models import User
 from gyrinx.maintenance.models import Backfill
 from n26.core.models import Assignment, Gang
 from n26.core.reconcile import assert_reconciled
-from n26.library.deletion import plan_deletion
+from n26.library.deletion import DeletionPlan, Line, plan_deletion
 from n26.library.models import WeaponProfile
 from n26.tests.sandbox.actions import (
     buy_weapon_profile,
@@ -201,6 +201,64 @@ class TestThePage:
         assert "paid for" in response.content.decode()
         assert WeaponProfile.objects.filter(pk=incisor.pk).exists()
         assert not Backfill.objects.exists()
+
+    def test_a_replayed_delivery_finds_nothing_left_to_remove(
+        self, author, player, escher, ganger, claw, incisor
+    ):
+        from n26.library.deletion import remove_free_lines_from
+
+        theirs = armed(player, "Theirs", escher, ganger, claw)
+        plan = plan_deletion([incisor], remove_free_lines=True)
+        first = remove_free_lines_from(theirs.pk, plan)
+        assert "deleted" in first
+
+        again = remove_free_lines_from(theirs.pk, plan)
+
+        assert "already gone" in again
+
+    def test_a_fighter_who_paid_mid_run_fails_the_gang_in_words(
+        self, author, player, escher, ganger, claw, incisor
+    ):
+        from n26.library.authoring import revise
+        from n26.library.deletion import Refused, remove_free_lines_from
+
+        theirs = armed(player, "Theirs", escher, ganger, claw)
+        plan = plan_deletion([incisor], remove_free_lines=True)
+        # A second fighter buys the line, paid, after the plan was read.
+        revise(incisor, price=10)
+        second = hire(theirs, ganger, "Late", paid=50)
+        weapon_line = give_weapon(second, claw, paid=30)
+        buy_weapon_profile(weapon_line, incisor)
+        plan_now = plan_deletion([incisor], remove_free_lines=True)
+        assert not plan_now.ok
+
+        # The gang's own stored lines are still free, so this gang is
+        # settled; the paid one is on a fighter the plan never named,
+        # and the row stays because something still names it.
+        said = remove_free_lines_from(theirs.pk, plan)
+        assert "removed the line from 1 fighter" in said
+        assert "deleted" not in said
+        assert WeaponProfile.objects.filter(pk=incisor.pk).exists()
+
+        # A stored line that was paid for since fails the gang.
+        paid_line = Assignment.objects.get(
+            gang_root=theirs, weapon_profile=incisor, parent=weapon_line
+        )
+        stale = DeletionPlan(
+            targets=plan.targets,
+            lines=(
+                Line(
+                    pk=str(theirs.pk),
+                    name=theirs.name,
+                    owner="player",
+                    archived=False,
+                    fighters=("Late",),
+                    assignment_ids=(str(paid_line.pk),),
+                ),
+            ),
+        )
+        with pytest.raises(Refused):
+            remove_free_lines_from(theirs.pk, stale)
 
     def test_an_unused_line_is_deleted_in_the_request(self, author, client, incisor):
         body = client.get(delete_page(incisor)).content.decode()

--- a/n26/tests/sandbox/test_merge_into.py
+++ b/n26/tests/sandbox/test_merge_into.py
@@ -305,6 +305,26 @@ class TestThePage:
         assert "line “scatter ammo” becomes" in shown
         assert f"Merge {duplicate.authoring_label} into Shotgun" in shown
 
+    def test_a_survivor_that_is_not_an_id_asks_again(self, author, client, duplicate):
+        body = client.get(merge_page(duplicate) + "?into=not-an-id").content.decode()
+        assert "Read the plan" in body
+        assert "What merging does" not in body
+
+    def test_a_replayed_delivery_finds_nothing_left_to_move(
+        self, author, player, escher, ganger, shotgun, duplicate
+    ):
+        from n26.library.merging import merge_gang
+
+        theirs = armed_with(player, "Theirs", escher, ganger, duplicate)
+        plan = plan_merge(duplicate, shotgun)
+        first = merge_gang(theirs.pk, plan)
+        assert "deleted" in first
+
+        again = merge_gang(theirs.pk, plan)
+
+        assert "already gone" in again
+        assert Weapon.objects.filter(pk=shotgun.pk).exists()
+
     def test_the_weapon_page_offers_the_way_there(self, author, client, duplicate):
         body = client.get(f"/n26/authoring/weapon/{duplicate.pk}/").content.decode()
         assert merge_page(duplicate) in body

--- a/n26/tests/sandbox/test_test_content_deletion.py
+++ b/n26/tests/sandbox/test_test_content_deletion.py
@@ -108,6 +108,34 @@ class TestNamingTheTestGangs:
         assert any(gang.name in words and "player" in words for words in plan.refusals)
         assert any("not staff" in words for words in plan.refusals)
 
+    def test_a_purchase_through_a_list_line_does_not_hold_the_line(
+        self, player, test_type, test_fighter, test_weapon
+    ):
+        """A purchase names the line it was bought through, and the
+        column is emptied when the line goes: the payment still
+        happened. So a player's purchase does not hold a staged line."""
+        from n26.library.authoring import create_collection
+        from n26.library.models import CollectionEntry
+        from n26.tests.sandbox.actions import buy
+
+        listing = create_collection("Test list", entries=[(test_weapon, {})])
+        entry = CollectionEntry.objects.get(collection=listing)
+        entry.staged = True
+        entry.save()
+        gang = found_gang("Theirs", test_type, owner=player)
+        model = hire(gang, test_fighter, "One", paid=50)
+        buy(model, thing=test_weapon, entry=entry, paid=15)
+
+        plan = plan_deletion([entry])
+
+        assert plan.ok
+        assert not plan.gangs
+        apply(plan)
+        assert not CollectionEntry.objects.filter(pk=entry.pk).exists()
+        assert Assignment.objects.filter(
+            gang_root=gang, weapon=test_weapon, ledger_entry__bought_from=None
+        ).exists()
+
     def test_a_gang_type_refuses_while_its_fighters_stand(
         self, test_type, test_fighter
     ):


### PR DESCRIPTION
Stacked on #2526. Review feedback across #2523, #2524 and #2526, from Copilot, CodeQL and a full read of the combined diff.

## Correctness

- **A column the model empties no longer makes a gang a holder.** A purchase's list line (`LedgerEntry.bought_from`) and a pick's offer (`Assignment.chosen_for_offer`) are SET_NULL by design: the row they name may go while the row naming it stays true. The planner now skips them, so a player's purchase through a staged list line does not block deleting the line, and does not pull a test gang into a delete for it.
- **Test campaigns are locked** before the plan is read again, so a player cannot join one between the second reading and the delete.
- **A gang that refuses mid-walk fails the run.** `remove_free_lines_from` and `merge_gang` raise rather than returning a skipped line, so the record cannot end as Deleted with the row still standing.
- **Per-gang work is bounded.** `remove_free_lines_from` re-checks only the visited gang's own stored lines under its lock instead of re-planning the whole estate per gang; the planner reads each gang once however many fighters hold the line.
- **Redelivery is idempotent.** A row already deleted by the last gang makes a replayed batch report nothing left to do rather than fail.
- A malformed `?into=` on the merge page asks again instead of raising.

## Pages

- Test campaigns are drawn in their own section with their own words; the firing-line lead no longer promises a removal a refusal prevents; an empty "Delete everything staged" draws no button and posts nothing.
- Refusals redirect to an address the view reverses, not `request.path` (CodeQL).
- The kit's badge takes `zinc` and no `class`; the "Archived" mark was losing its styling.

## Merge

- `merge_library` builds the survivor line map once and swaps many-to-many members for their own counterparts; the free-line grant states the limit it shares with the purchase path; the merge view reads `Operation.MERGE_INTO` through the seam.

## Left alone

- `said_by_whoever_enqueued_it` is the name every task in `n26/maintenance.py` uses; renaming one is not this stack's change.
- "content that has been used is history, not clutter" in `_deleting` predates this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cZmwCpLyQVfART55StrdX
