### PR TITLE
refactor: add at_most and use it for the equip_price min

### DIFF
--- a/n26/core/templates/n26/includes/equip_price.html
+++ b/n26/core/templates/n26/includes/equip_price.html
@@ -1,3 +1,4 @@
+{% load arith %}
 {% comment %}
 The price of one buyable line, as a box you can type in, with what changing it
 did printed beside it. Expects `field` (the input's name), `quoted` (the price
@@ -35,7 +36,7 @@ refuse the form before the server ever saw it.
     <input type="number"
            name="{{ field }}"
            value="{{ quoted }}"
-           min="{% if quoted < 0 %}{{ quoted }}{% else %}0{% endif %}"
+           min="{{ quoted|at_most:0 }}"
            max="{{ price_cap }}"
            step="1"
            inputmode="numeric"

--- a/n26/core/templatetags/arith.py
+++ b/n26/core/templatetags/arith.py
@@ -31,3 +31,17 @@ def at_least(value, minimum):
         return max(int(value), int(minimum))
     except TypeError, ValueError:
         return minimum
+
+
+@register.filter
+def at_most(value, maximum):
+    """Cap a number — ``{{ quoted|at_most:0 }}`` is the least a price box
+    may hold, which is the quote where the quote is below zero.
+
+    Coerces first, because a value reaches a template as a string as
+    often as a number, and a comparison between the two is not an answer.
+    """
+    try:
+        return min(int(value), int(maximum))
+    except TypeError, ValueError:
+        return maximum

--- a/n26/core/test_arith.py
+++ b/n26/core/test_arith.py
@@ -1,0 +1,37 @@
+"""The arithmetic filters, on the inputs a template really hands them.
+
+A value reaches a filter as a string as often as a number — a component
+attribute written without a colon is text — so each filter coerces before
+it compares, and a value it cannot read yields its bound rather than an
+error.
+"""
+
+import pytest
+
+from n26.core.templatetags.arith import at_least, at_most, sub
+
+
+class TestAtMost:
+    """The least a price box may hold is the quote where the quote is
+    below zero, and zero otherwise — read the same from a number or its
+    text."""
+
+    @pytest.mark.parametrize("quoted", [-10, "-10"])
+    def test_a_quote_below_zero_is_the_floor(self, quoted):
+        assert at_most(quoted, 0) == -10
+
+    @pytest.mark.parametrize("quoted", [0, "0", 35, "35"])
+    def test_a_quote_at_or_above_zero_floors_at_zero(self, quoted):
+        assert at_most(quoted, 0) == 0
+
+    def test_something_unreadable_yields_the_bound(self):
+        assert at_most("", 0) == 0
+        assert at_most(None, 0) == 0
+
+
+class TestTheOthersStillCoerce:
+    def test_at_least_from_text(self):
+        assert at_least("2", 1) == 2
+
+    def test_sub_from_text(self):
+        assert sub("5", "2") == 3

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -48,12 +48,11 @@ from n26.library.staged import sees_staged
 #: without a budget has nothing else to stop it.
 PRICE_CEILING = 100_000
 
-#: A price is a whole number of credits, written in plain digits.
-#: Python's own ``int`` would also take "-5", "+5", "1_0" and digits from
-#: other scripts, none of which a price field should quietly accept.
-#: A whole number of credits, optionally below zero. Whether a minus is
-#: allowed for one particular purchase is ``price_floor``'s question, not
-#: the shape's.
+#: A price is a whole number of credits in plain digits, with at most a
+#: leading minus. Python's own ``int`` would also take "+5", "1_0" and
+#: digits from other scripts, none of which a price field should quietly
+#: accept. Whether the minus is allowed for one particular purchase is
+#: ``price_floor``'s question, not the shape's.
 _WHOLE_CREDITS = re.compile(r"-?[0-9]+")
 
 
@@ -145,12 +144,13 @@ def price_typed(data, field, quoted, name):
         return quoted
     raw = raw.strip()
     floor = price_floor(quoted)
-    if not _WHOLE_CREDITS.fullmatch(raw) or not floor <= int(raw) <= PRICE_CEILING:
+    typed = int(raw) if _WHOLE_CREDITS.fullmatch(raw) else None
+    if typed is None or not floor <= typed <= PRICE_CEILING:
         raise BadPrice(
             f"{name}: a price is a whole number of credits, "
             f"from {floor} to {PRICE_CEILING}."
         )
-    return int(raw)
+    return typed
 
 
 def price_floor(quoted):


### PR DESCRIPTION
Follow-up to #2528, which merged before its reviewer's three comments could be taken in. All three were right, none was a bug in production, and this closes them.

**The price box's floor was decided in the template**, by comparing the quote with zero. The hire dialog hands that include its quote as text, and Django's comparison swallows the type mismatch rather than raising — so the floor came out right, but by accident. It is now an arithmetic filter beside the existing floor filter, coercing before it compares, so it reads the same from a number or its text. A profile is never priced below zero, so the hire dialog's answer does not change; what changes is that it is no longer an accident.

**The typed price is parsed once.** It was converted twice on the way to the range check.

**The comment over the credits pattern said plain digits and no minus**, one line above a pattern that allows a minus. It says one thing now.

Tests: the new filter from a number and from its text, at, above and below zero, and on something unreadable; and the sibling filters still coercing from text.

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pHmGSqVeKYH115Ye9xLsp
