### PR TITLE
feat: add pr-screenshots workflow for agent-created PRs

### DIFF
--- a/.agents/skills/dev-server/SKILL.md
+++ b/.agents/skills/dev-server/SKILL.md
@@ -143,6 +143,21 @@ echo "http://localhost:$(worktree_port)"
 The CSRF_TRUSTED_ORIGINS in `settings_dev.py` dynamically includes the worktree port, so
 form submissions work correctly on any port.
 
+## Capturing PR evidence
+
+After exercising a meaningful UI change, load the `pr-screenshots` skill to choose
+and attach useful review evidence. Browser tooling can save a capture directly;
+for a named Django URL, `scripts/screenshot.py` uses this worktree's port and a
+minted local staff session:
+
+```bash
+.codex/run.sh python scripts/screenshot.py core:campaign \
+  --args <campaign-id> --after --output-dir screenshots/<task>
+```
+
+Keep captures under the gitignored `screenshots/` directory until the
+`pr-screenshots` workflow uploads them to the pull request.
+
 ## Logging in for browser testing
 
 Do **not** submit `/accounts/login/` from an agent session. The form always includes

--- a/.agents/skills/pr-screenshots/SKILL.md
+++ b/.agents/skills/pr-screenshots/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: pr-screenshots
+description: Capture useful UI evidence and attach it to GitHub pull requests. Load when a change affects rendered UI, when working in a cloud environment where the user cannot see the browser, or when creating or rewriting a PR that contains screenshots.
+---
+
+# PR screenshots
+
+Give reviewers visual evidence when it helps them understand or verify a change.
+This is a strong default for meaningful changes to rendered UI, particularly in a
+cloud session where the user cannot see the browser. Use judgment: backend-only
+changes and tiny visual changes may not benefit from a screenshot. If a visible
+change has no capture, say briefly why in the PR.
+
+## Choose useful evidence
+
+- Prefer a focused **after** screenshot that shows the changed state in context.
+- Add **before and after** only when the comparison explains the change better.
+- Capture multiple viewports only when responsive behaviour changed.
+- Use a short video instead of many screenshots when the interaction is the change.
+- Do not capture every manual test step. Choose the smallest set that helps review.
+- Use synthetic or local data. Check images for personal data, credentials, tokens,
+  private campaign details, and debug output before uploading them.
+
+## Capture locally
+
+Load the `dev-server` skill, start the worktree server, and exercise the real UI.
+Browser tooling may save a capture directly. For a named Django URL, the helper is:
+
+```bash
+.codex/run.sh python scripts/screenshot.py core:campaign \
+  --args <campaign-id> \
+  --after \
+  --output-dir screenshots/<task>
+```
+
+The helper uses the worktree's `DJANGO_PORT` and mints a local staff session for
+`agent` by default. `screenshots/` is gitignored: it is staging, not the durable
+home of the review evidence.
+
+## Attach to the PR
+
+GitHub CLI 2.99 or newer uploads local images and rewrites matching Markdown image
+paths when `--attach` is supplied. Put the images in a `## Screenshots` section of
+the PR body, then pass each local file with a repeated flag:
+
+```markdown
+## Screenshots
+
+![Campaign equipment after the change](screenshots/equipment/after.png)
+```
+
+```bash
+gh pr create --title "..." --body-file /tmp/pr-body.md \
+  --attach screenshots/equipment/after.png
+```
+
+For an existing PR:
+
+```bash
+gh pr edit <number> --body-file /tmp/pr-body.md \
+  --attach screenshots/equipment/after.png
+```
+
+When rewriting a PR body, preserve valid existing screenshot URLs or replace them
+with fresh captures when the UI changed again. Do not silently drop the section.
+
+Verify the result:
+
+```bash
+gh pr view <number> --json body --jq .body
+```
+
+The body should contain a GitHub-hosted attachment URL, not a local path. If the
+installed CLI lacks `--attach`, use GitHub's browser uploader when available. If
+neither route is available, report the local artifact path and the limitation;
+do not commit generated images merely to satisfy this guidance.

--- a/.claude/commands/manual-test-plan.md
+++ b/.claude/commands/manual-test-plan.md
@@ -46,6 +46,8 @@ For each test case, provide:
 - **Name**: Brief description
 - **Steps**: Numbered list of exact UI actions (click, type, select, etc.)
 - **Expected Result**: What should be visible on screen after the action
+- **Suggested Capture**: The state that would make useful PR evidence, or `None`
+  when a screenshot would add little value
 
 ### 3. Format Requirements
 
@@ -55,6 +57,11 @@ Format the test plan so Claude for Chrome can execute it step-by-step:
 - Include what to look for to verify success (e.g., "The credits value in the header should increase from X to Y")
 - Note any checkboxes or form fields to interact with
 - Specify page navigation clearly (e.g., "Navigate to the fighter's detail page by clicking on their name")
+- Suggest only the smallest useful set of screenshots. Prefer a focused final
+  state; use before/after or multiple viewports only when the comparison matters.
+- The browser executor should save suggested captures under the gitignored
+  `screenshots/<task>/` directory when it has filesystem access. Loading and
+  attaching them to the PR is handled separately by the `pr-screenshots` skill.
 
 ### 4. Human Assistance Required
 
@@ -127,6 +134,8 @@ Steps:
 **Verify**:
 - [ ] [Expected visual result]
 - [ ] [Expected visual result]
+
+**Suggested Capture**: [Useful final state, or None]
 
 ## Test 2: [Test Name]
 ...

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -36,6 +36,9 @@ const options = {
         "**/.venv",
         "**/venv",
         "playbooks",
+        // Generated, git-ignored browser evidence is not repository documentation.
+        "screenshots",
+        "ui_archive",
         // Git-ignored local research material (see CLAUDE.local.md);
         // mirrored pages fail link-fragment rules and are not ours to fix.
         "rule-reference",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,9 @@ Skills are loaded automatically by agents that need them. They can also be refer
 - **dev-server** — Knowledge about starting/stopping the dev server, reading ports, telling Claude in Chrome
   where to point, log file locations, **and how to mint a session cookie for the browser**. Do not POST
   `/accounts/login/` from an agent session; reCAPTCHA and mandatory email verification block it.
+- **pr-screenshots** — Capture useful UI evidence and attach it to a PR with GitHub-native attachments.
+  Load for meaningful rendered UI changes, especially when working in a cloud session where the user cannot
+  see the browser, and when preserving or refreshing screenshots while rewriting a PR description.
 - **worktree-db** — Knowledge about per-worktree database isolation: forking, resetting, migrating, cleanup,
   template workflow, pgAdmin access
 
@@ -349,6 +352,11 @@ titles, which should freely name model classes, functions and flags.
 
 - Manually test changes through the running app (dev server + browser) before
   shipping — skip only when the change is trivial
+- For a change that meaningfully alters rendered UI, normally attach one or more
+  useful captures to the PR so reviewers can see the result. This matters most in
+  cloud sessions where the user cannot see the browser. Use judgment rather than
+  treating this as a gate: omit captures when they add little value, and say why.
+  Load the **pr-screenshots** skill for capture, privacy, and upload guidance.
 - **Always smoke-test a migration, backfill, or any data-touching feature on a
   real database before shipping it.** Fork the content mirror
   (`createdb -T gyrinx_main gyrinx_smoke`), build a population at production's
@@ -758,6 +766,8 @@ and override the `owner` kwarg on the factory fixtures.
   and reach for `git stash` only in a plain single checkout.
 - This keeps `CLAUDE.local.md` up to date across pulls.
 - When writing PR descriptions, keep it simple and avoid "selling the feature" in the PR
+- When updating a PR description that already contains screenshots, preserve
+  valid captures or refresh them if later commits changed the rendered result.
 - At the end of work, ship with the `commit-push-pr` skill — open the PR ready for
   review (not a draft) so bot reviews and the review-agent watcher kick off
   immediately. Only use `commit-push-draft` when a draft is explicitly requested.

--- a/gyrinx/tests/test_screenshot_script.py
+++ b/gyrinx/tests/test_screenshot_script.py
@@ -1,0 +1,78 @@
+import asyncio
+
+import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+
+from scripts import screenshot
+
+
+def test_server_url_uses_worktree_port(monkeypatch):
+    monkeypatch.setenv("DJANGO_PORT", "8322")
+
+    assert screenshot.get_server_port() == 8322
+    assert screenshot.get_server_url() == "http://localhost:8322"
+
+
+def test_server_url_defaults_to_port_8000(monkeypatch):
+    monkeypatch.delenv("DJANGO_PORT", raising=False)
+
+    assert screenshot.get_server_url() == "http://localhost:8000"
+
+
+def test_capture_uses_requested_username(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeCapture:
+        def __init__(self, server_url=None, username="agent"):
+            captured["username"] = username
+
+        async def capture_screenshot(self, **kwargs):
+            return True
+
+    monkeypatch.setattr(screenshot, "ScreenshotCapture", FakeCapture)
+
+    success = asyncio.run(
+        screenshot.capture_screenshots(
+            "core:campaign",
+            output_dir=tmp_path,
+            username="reviewer",
+        )
+    )
+
+    assert success is True
+    assert captured["username"] == "reviewer"
+
+
+def test_after_only_comparison_has_complete_document(tmp_path):
+    capture = screenshot.ScreenshotCapture()
+
+    capture._update_comparison_markdown(
+        tmp_path,
+        "core:campaign",
+        "after",
+        "campaign_after.png",
+        "mobile",
+    )
+
+    comparison = tmp_path / "core_campaign_mobile_comparison.md"
+    assert comparison.read_text() == (
+        "# core:campaign UI changes\n\n"
+        "**Viewport:** mobile\n\n"
+        "## After\n"
+        "![After](./campaign_after.png)\n\n"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(DEBUG=True)
+def test_authenticate_creates_local_staff_user():
+    capture = screenshot.ScreenshotCapture(username="screenshot-reviewer")
+
+    cookie = asyncio.run(capture.authenticate())
+
+    user = get_user_model().objects.get(username="screenshot-reviewer")
+    assert user.is_staff is True
+    assert user.is_superuser is True
+    assert cookie["name"] == settings.SESSION_COOKIE_NAME

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,20 +12,20 @@ Automated UI screenshot utility using Playwright for capturing views without man
 
 ```bash
 # Basic usage
-python scripts/screenshot.py <url_name> [options]
+.codex/run.sh python scripts/screenshot.py <url_name> [options]
 
 # Capture before/after screenshots for UI changes
-python scripts/screenshot.py core:campaign --before --args <campaign_id>
-python scripts/screenshot.py core:campaign --after --args <campaign_id>
+.codex/run.sh python scripts/screenshot.py core:campaign --before --args <campaign_id>
+.codex/run.sh python scripts/screenshot.py core:campaign --after --args <campaign_id>
 
 # Multiple viewports
-python scripts/screenshot.py core:list --viewports desktop,mobile --args <list_id>
+.codex/run.sh python scripts/screenshot.py core:list --viewports desktop,mobile --args <list_id>
 
 # Specific element only
-python scripts/screenshot.py core:campaign --selector ".campaign-header" --args <id>
+.codex/run.sh python scripts/screenshot.py core:campaign --selector ".campaign-header" --args <id>
 
 # Check Playwright installation
-python scripts/screenshot.py --check
+.codex/run.sh python scripts/screenshot.py --check
 ```
 
 **Options:**
@@ -37,25 +37,36 @@ python scripts/screenshot.py --check
 - `--label`: Custom label for the screenshot
 - `--viewports`: Comma-separated viewports (desktop,tablet,mobile)
 - `--theme`: Color scheme (light/dark, default: light)
-- `--output-dir`: Output directory (default: ui_archive)
+- `--output-dir`: Output directory (default: screenshots)
 - `--selector`: CSS selector for specific element
 - `--no-full-page`: Capture only viewport (not full page)
-- `--username`: Username to authenticate as (default: admin)
+- `--username`: Local staff username to authenticate as (default: agent)
 - `--check`: Check if Playwright is installed
 
 **Requirements:**
 
 - Playwright is a locked dependency, so `uv sync --locked` installs it
-- Django project must be properly configured
-- User account must exist for authentication
+- Run through `.codex/run.sh` so the script uses the worktree's database and port
+- The named local staff user is created if it does not exist
 - Chromium browser will be automatically installed on first run
 
 **Output:**
 
-- Screenshots are saved to `ui_archive/` directory
+- Screenshots are saved to the gitignored `screenshots/` directory
 - Files are named: `<url_name>_<label>_<viewport>_<timestamp>.png`
 - Latest versions: `<url_name>_<label>_<viewport>_latest.png`
 - Comparison markdown is generated for before/after pairs
+
+For pull-request evidence, load the `pr-screenshots` skill. Put local image paths
+in a `## Screenshots` section of the PR body and upload them with GitHub CLI 2.99+:
+
+```bash
+gh pr create --body-file /tmp/pr-body.md \
+  --attach screenshots/<task>/after.png
+```
+
+GitHub replaces the local Markdown path with a durable user-attachment URL. Keep
+the generated image out of git and check it for private data before uploading.
 
 ### Other Scripts
 

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -9,9 +9,9 @@ Usage:
     python scripts/screenshot.py <url_name> [options]
 
 Examples:
-    python scripts/screenshot.py core:campaign --before --args <campaign_id>
-    python scripts/screenshot.py core:list --after --args <list_id>
-    python scripts/screenshot.py core:campaign --viewports desktop,mobile --args <id>
+    .codex/run.sh python scripts/screenshot.py core:campaign --before --args <campaign_id>
+    .codex/run.sh python scripts/screenshot.py core:list --after --args <list_id>
+    .codex/run.sh python scripts/screenshot.py core:campaign --viewports desktop,mobile --args <id>
 """
 
 import argparse
@@ -55,8 +55,20 @@ VIEWPORTS = {
 }
 
 
-def check_server_running(host="localhost", port=8000):
+def get_server_port():
+    """Return the port configured for this worktree."""
+    return int(os.environ.get("DJANGO_PORT", "8000"))
+
+
+def get_server_url():
+    """Return the local development URL configured for this worktree."""
+    return f"http://localhost:{get_server_port()}"
+
+
+def check_server_running(host="localhost", port=None):
     """Check if the Django development server is running."""
+    if port is None:
+        port = get_server_port()
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(1)
     try:
@@ -105,39 +117,51 @@ def ensure_browser_installed():
 class ScreenshotCapture:
     """Handles automated screenshot capture using Playwright."""
 
-    def __init__(self, server_url="http://localhost:8000"):
-        self.server_url = server_url
+    def __init__(self, server_url=None, username="agent"):
+        self.server_url = server_url or get_server_url()
+        self.username = username
         self.client = Client()
 
-    async def authenticate(self, username="admin"):
-        """Authenticate using Django test client and return session cookie."""
+    async def authenticate(self, username=None):
+        """Mint a local staff session and return its cookie."""
+        if not settings.DEBUG:
+            raise RuntimeError(
+                "Screenshot sessions can only be minted with DEBUG enabled"
+            )
+        username = username or self.username
         User = get_user_model()
 
         @sync_to_async
         def get_user_and_login():
-            try:
-                user = User.objects.get(username=username)
-                self.client.force_login(user)
+            email = f"{username}@localhost"
+            user, created = User.objects.get_or_create(
+                username=username,
+                defaults={
+                    "email": email,
+                    "is_staff": True,
+                    "is_superuser": True,
+                },
+            )
+            if created:
+                user.set_password("password")
+            user.is_staff = True
+            user.is_superuser = True
+            if not user.email:
+                user.email = email
+            user.save()
+            self.client.force_login(user)
 
-                # Get session cookie
-                if hasattr(self.client, "cookies"):
-                    session_cookie = self.client.cookies.get(
-                        settings.SESSION_COOKIE_NAME
-                    )
-                    if session_cookie:
-                        return {
-                            "name": settings.SESSION_COOKIE_NAME,
-                            "value": session_cookie.value,
-                            "domain": "localhost",
-                            "path": "/",
-                            "httpOnly": True,
-                            "secure": False,
-                            "sameSite": "Lax",
-                        }
-            except User.DoesNotExist:
-                print(
-                    f"Warning: User '{username}' not found, proceeding without authentication"
-                )
+            session_cookie = self.client.cookies.get(settings.SESSION_COOKIE_NAME)
+            if session_cookie:
+                return {
+                    "name": settings.SESSION_COOKIE_NAME,
+                    "value": session_cookie.value,
+                    "domain": "localhost",
+                    "path": "/",
+                    "httpOnly": True,
+                    "secure": False,
+                    "sameSite": "Lax",
+                }
             return None
 
         return await get_user_and_login()
@@ -149,7 +173,7 @@ class ScreenshotCapture:
         label="",
         viewport="desktop",
         theme="light",
-        output_dir="ui_archive",
+        output_dir="screenshots",
         full_page=True,
         selector=None,
     ):
@@ -215,7 +239,7 @@ class ScreenshotCapture:
                 if "net::ERR_CONNECTION_REFUSED" in str(e):
                     print(f"\n✗ Error: Could not connect to {self.server_url}")
                     print("Please ensure the Django development server is running:")
-                    print("  python manage.py runserver")
+                    print("  ./scripts/dev.sh --no-watch")
                     await browser.close()
                     return False
                 else:
@@ -283,26 +307,21 @@ class ScreenshotCapture:
             return
 
         url_safe_name = url_name.replace(":", "_")
-        md_file = output_path / f"{url_safe_name}_comparison.md"
+        viewport_suffix = f"_{viewport}" if viewport != "desktop" else ""
+        md_file = output_path / f"{url_safe_name}{viewport_suffix}_comparison.md"
 
-        # Read existing content if file exists
-        existing_content = ""
-        if md_file.exists() and label == "after":
-            with open(md_file) as f:
-                existing_content = f.read()
-
-        with open(md_file, "w") as f:
-            if label == "before":
-                f.write(f"## {url_name} UI Changes\n\n")
+        mode = "a" if label == "after" and md_file.exists() else "w"
+        with open(md_file, mode) as f:
+            if mode == "w":
+                f.write(f"# {url_name} UI changes\n\n")
                 if viewport != "desktop":
                     f.write(f"**Viewport:** {viewport}\n\n")
-                f.write("### Before\n")
+
+            if label == "before":
+                f.write("## Before\n")
                 f.write(f"![Before](./{filename})\n\n")
             else:
-                # Write existing content first
-                if existing_content:
-                    f.write(existing_content)
-                f.write("### After\n")
+                f.write("## After\n")
                 f.write(f"![After](./{filename})\n\n")
 
         print(f"✓ Comparison markdown updated: {md_file}")
@@ -314,13 +333,13 @@ async def capture_screenshots(
     label="",
     viewports=None,
     theme="light",
-    output_dir="ui_archive",
+    output_dir="screenshots",
     full_page=True,
     selector=None,
-    username="admin",
+    username="agent",
 ):
     """Capture screenshots for specified viewports."""
-    capture = ScreenshotCapture()
+    capture = ScreenshotCapture(username=username)
 
     # Default to desktop if no viewports specified
     if not viewports:
@@ -375,7 +394,7 @@ def main():
         help="Color scheme for the screenshot",
     )
     parser.add_argument(
-        "--output-dir", type=str, help="Output directory", default="ui_archive"
+        "--output-dir", type=str, help="Output directory", default="screenshots"
     )
     parser.add_argument(
         "--selector", type=str, help="CSS selector to screenshot (default: full page)"
@@ -386,7 +405,7 @@ def main():
         help="Capture only the viewport (not full page)",
     )
     parser.add_argument(
-        "--username", type=str, default="admin", help="Username to authenticate as"
+        "--username", type=str, default="agent", help="Username to authenticate as"
     )
     parser.add_argument(
         "--check",
@@ -441,7 +460,7 @@ def main():
     if not check_server_running():
         print("\n✗ Error: Django development server is not running")
         print("Please start the server with:")
-        print("  python manage.py runserver")
+        print("  ./scripts/dev.sh --no-watch")
         print("\nThen run this command again.")
         sys.exit(1)
 

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -40,28 +40,40 @@ fi
 # 1. Install GitHub CLI
 # ---------------------------------------------------------------------------
 echo "--- [1/9] Installing GitHub CLI ---"
-if ! command -v gh &>/dev/null; then
+if command -v gh &>/dev/null \
+  && gh pr create --help 2>/dev/null | grep -q -- '--attach'; then
+  echo "gh already supports PR attachments: $(gh --version | head -1)"
+else
   # Install from a direct binary download rather than apt.
   # The web environment has limited network; apt-get update fails because
   # it tries to reach every configured apt source (PPAs, etc.).  Direct
   # download only needs github.com + objects.githubusercontent.com, both
-  # on the allow-list.
-  GH_VERSION="2.67.0"
+  # on the allow-list. gh 2.99+ is required for `gh pr create --attach`.
+  GH_VERSION="2.100.0"
   # Map kernel arch to the naming convention used by gh release tarballs.
   case "$(uname -m)" in
-    x86_64)  GH_ARCH="amd64" ;;
-    aarch64) GH_ARCH="arm64" ;;
-    *)       GH_ARCH="$(uname -m)" ;;
+    x86_64)
+      GH_ARCH="amd64"
+      GH_SHA256="e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be"
+      ;;
+    aarch64)
+      GH_ARCH="arm64"
+      GH_SHA256="ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961"
+      ;;
+    *)
+      echo "Unsupported architecture for GitHub CLI: $(uname -m)" >&2
+      exit 1
+      ;;
   esac
   GH_TARBALL="gh_${GH_VERSION}_linux_${GH_ARCH}"
+  GH_TMP_DIR=$(mktemp -d)
   curl -LsSf "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}.tar.gz" \
-    -o /tmp/gh.tar.gz
-  tar -xzf /tmp/gh.tar.gz -C /tmp
-  sudo install /tmp/"${GH_TARBALL}"/bin/gh /usr/local/bin/gh
-  rm -rf /tmp/gh.tar.gz /tmp/"${GH_TARBALL}"
+    -o "${GH_TMP_DIR}/${GH_TARBALL}.tar.gz"
+  echo "${GH_SHA256}  ${GH_TMP_DIR}/${GH_TARBALL}.tar.gz" | sha256sum -c -
+  tar -xzf "${GH_TMP_DIR}/${GH_TARBALL}.tar.gz" -C "${GH_TMP_DIR}"
+  sudo install "${GH_TMP_DIR}/${GH_TARBALL}/bin/gh" /usr/local/bin/gh
+  rm -r "${GH_TMP_DIR}"
   echo "gh installed: $(gh --version | head -1)"
-else
-  echo "gh already installed: $(gh --version | head -1)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make screenshots a strong, discretionary default for meaningful rendered UI changes, with focused guidance for cloud agents
- capture authenticated screenshots against each worktree's real port and keep generated evidence in gitignored staging
- install a GitHub CLI version with native `gh pr create/edit --attach` support in Claude web environments

## Test plan

- [x] `.codex/run.sh pytest -n 0 gyrinx/tests/test_screenshot_script.py` (5 passed)
- [x] `.codex/run.sh pytest -n auto` (10,670 passed, 12 skipped, 1 xfailed)
- [x] `./scripts/fmt.sh`
- [x] pre-commit checks on all changed files
- [x] `bash -n scripts/setup_web.sh`
- [x] validate `.agents/skills/pr-screenshots` with the skill validator
- [x] capture `core:index` from the running worktree server on port 8322 and confirm the image contains the authenticated `agent` session

## Screenshots

Not included: this PR changes agent instructions and developer tooling rather than rendered product UI. The capture helper itself was exercised end to end as noted above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are agent docs and local dev tooling; screenshot session minting is gated on DEBUG and does not affect production runtime.
> 
> **Overview**
> Introduces a **`pr-screenshots`** agent skill and wires it through **`CLAUDE.md`**, **`dev-server`**, and the **manual test plan** so meaningful UI work should get focused review captures (especially in cloud sessions), staged under gitignored **`screenshots/`**, and uploaded with **`gh pr create/edit --attach`** (CLI 2.99+).
> 
> **`scripts/screenshot.py`** now targets each worktree’s **`DJANGO_PORT`**, defaults output to **`screenshots/`** and login to **`agent`**, mints a local staff session in **DEBUG** (creating the user if needed) instead of requiring a pre-existing admin, and improves before/after comparison markdown. **`scripts/setup_web.sh`** installs or upgrades **GitHub CLI 2.100** when **`--attach`** is missing (with checksum verification). **Markdownlint** ignores **`screenshots/`** and **`ui_archive/`**; new tests cover port URL helpers, auth, and comparison output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc25879517fd6f1908f888f35cebab0f89c8c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->